### PR TITLE
Add `findMedCon` command to find patients base on their medical conditions

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -14,8 +14,7 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_PERSON_NRIC_NOT_FOUND = "Unable to find the patient to delete with the given "
-            + "NRIC";
+    public static final String MESSAGE_PERSON_NRIC_NOT_FOUND = "The patient with the specified NRIC does not exist";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d patients listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -52,12 +52,18 @@ public class Messages {
                 .append(person.getEmail())
                 .append("\nAddress: ")
                 .append(person.getAddress())
-                .append("\nMedical Conditions: ");
+                .append("\nPriority: ")
+                .append(person.getPriority());
+
+        builder.append("\nMedical Conditions: ");
         appendWithComma(builder, person.getMedCons());
+
         builder.append("\nAppointments: ");
         appendWithComma(builder, person.getAppointments());
+
         builder.append("\nTags: ");
         appendWithComma(builder, person.getTags());
+
         return builder.toString();
     }
 

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -67,6 +67,12 @@ public class Messages {
         return builder.toString();
     }
 
+    /**
+     * Appends the {@code toAppend} to the {@code builder} with a comma.
+     *
+     * @param builder The StringBuilder to append to.
+     * @param toAppend The Set to append.
+     */
     private static void appendWithComma(StringBuilder builder, Set<?> toAppend) {
         String result = toAppend.stream()
                 .map(Object::toString)

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -40,21 +40,31 @@ public class Messages {
     public static String format(Person person) {
         final StringBuilder builder = new StringBuilder();
         builder.append(person.getName())
-                .append("; NRIC: ")
+                .append("\nNRIC: ")
                 .append(person.getNric())
-                .append("; Gender: ")
+                .append("\nGender: ")
                 .append(person.getGender())
-                .append("; Date of Birth: ")
+                .append("\nDate of Birth: ")
                 .append(person.getDateOfBirth())
-                .append("; Phone: ")
+                .append("\nPhone: ")
                 .append(person.getPhone())
-                .append("; Email: ")
+                .append("\nEmail: ")
                 .append(person.getEmail())
-                .append("; Address: ")
+                .append("\nAddress: ")
                 .append(person.getAddress())
-                .append("; Tags: ");
-        person.getTags().forEach(builder::append);
+                .append("\nMedical Conditions: ");
+        appendWithComma(builder, person.getMedCons());
+        builder.append("\nAppointments: ");
+        appendWithComma(builder, person.getAppointments());
+        builder.append("\nTags: ");
+        appendWithComma(builder, person.getTags());
         return builder.toString();
     }
 
+    private static void appendWithComma(StringBuilder builder, Set<?> toAppend) {
+        String result = toAppend.stream()
+                .map(Object::toString)
+                .collect(Collectors.joining(", "));
+        builder.append(result);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/FindMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindMedConCommand.java
@@ -1,0 +1,49 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
+
+/**
+ * Finds and lists all patients in the address book who have medical conditions that contain any of the
+ * argument keywords.
+ * Keyword matching is case-insensitive.
+ */
+public class FindMedConCommand extends Command {
+    public static final String COMMAND_WORD = "findMedCon";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients with medical conditions that"
+            + "contains the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
+            + "Parameters: "
+            + "MEDICAL CONDITION [MORE_MEDICAL_CONDITIONS]\n"
+            + "Example: " + COMMAND_WORD + " diabetes hypertension";
+    private final MedConContainsKeywordsPredicate predicate;
+    public FindMedConCommand(MedConContainsKeywordsPredicate predicate) {
+        this.predicate = predicate;
+    }
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredPersonList(predicate);
+        return new CommandResult(
+                String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredPersonList().size()));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        //instanceof handles nulls
+        if (!(other instanceof FindMedConCommand)) {
+            return false;
+        }
+
+        FindMedConCommand otherFindMedConCommand = (FindMedConCommand) other;
+        return predicate.equals(otherFindMedConCommand.predicate);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FindMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindMedConCommand.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
+import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.Messages;
 import seedu.address.model.Model;
 import seedu.address.model.person.MedConContainsKeywordsPredicate;
@@ -17,8 +18,8 @@ public class FindMedConCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all patients with medical conditions that"
             + "contains the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: "
-            + "MEDICAL CONDITION [MORE_MEDICAL_CONDITIONS]\n"
-            + "Example: " + COMMAND_WORD + " diabetes hypertension";
+            + "KEYWORD [MORE KEYWORDS]\n"
+            + "Example: " + COMMAND_WORD + " diabetes cancer";
     private final MedConContainsKeywordsPredicate predicate;
     public FindMedConCommand(MedConContainsKeywordsPredicate predicate) {
         this.predicate = predicate;
@@ -45,5 +46,12 @@ public class FindMedConCommand extends Command {
 
         FindMedConCommand otherFindMedConCommand = (FindMedConCommand) other;
         return predicate.equals(otherFindMedConCommand.predicate);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .add("predicate", predicate)
+                .toString();
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -58,24 +58,34 @@ public class AddressBookParser {
         switch (commandWord) {
         case AddCommand.COMMAND_WORD:
             return new AddCommandParser().parse(arguments);
+
         case EditCommand.COMMAND_WORD:
             return new EditCommandParser().parse(arguments);
+
         case DeleteCommand.COMMAND_WORD:
             return new DeleteCommandParser().parse(arguments);
+
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
+
         case FindCommand.COMMAND_WORD:
             return new FindCommandParser().parse(arguments);
+
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();
+
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
         case PriorityCommand.COMMAND_WORD:
             return new PriorityCommandParser().parse(arguments);
+
         case AddApptCommand.COMMAND_WORD:
             return new AddApptCommandParser().parse(arguments);
+
         case DeleteApptCommand.COMMAND_WORD:
             return new DeleteApptCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -18,6 +18,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindMedConCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.PriorityCommand;
@@ -91,6 +92,9 @@ public class AddressBookParser {
 
         case AddMedConCommand.COMMAND_WORD:
             return new AddMedConCommandParser().parse(arguments);
+
+        case FindMedConCommand.COMMAND_WORD:
+            return new FindMedConCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -11,9 +11,8 @@ import seedu.address.model.person.Nric;
 import seedu.address.model.person.NricMatchesPredicate;
 
 
-
 /**
- * Parses input arguments and creates a new DeleteCommand object
+ * Parses input arguments and creates a new DeleteCommand object.
  */
 public class DeleteCommandParser implements Parser<DeleteCommand> {
     private static final Logger logger = LogsCenter.getLogger(DeleteCommandParser.class);
@@ -21,7 +20,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * Parses the given {@code String} of arguments in the context of the DeleteCommand
      * and returns a DeleteCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteCommand parse(String args) throws ParseException {
         try {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -9,13 +9,14 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 
 /**
- * Parses input arguments and creates a new FindCommand object
+ * Parses input arguments and creates a new FindCommand object.
  */
 public class FindCommandParser implements Parser<FindCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -17,7 +17,7 @@ public class FindCommandParser implements Parser<FindCommand> {
      * Parses the given {@code String} of arguments in the context of the FindCommand
      * and returns a FindCommand object for execution.
      *
-     * @throws ParseException if the user input does not conform the expected format
+     * @throws ParseException if the user input does not conform the expected format.
      */
     public FindCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();

--- a/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.FindMedConCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
+
+import java.util.Arrays;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+/**
+ * Parses input arguments and creates a new FindMedConCommand object.
+ */
+public class FindMedConCommandParser implements Parser<FindMedConCommand> {
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListMedConCommand
+     * and returns a ListMedConCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public FindMedConCommand parse(String args) throws ParseException {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMedConCommand.MESSAGE_USAGE));
+        }
+
+        String[] medConKeywords = trimmedArgs.split("\\s+");
+        MedConContainsKeywordsPredicate predicate = new MedConContainsKeywordsPredicate(Arrays.asList(medConKeywords));
+        return new FindMedConCommand(predicate);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.parser;
 
-import seedu.address.logic.commands.FindMedConCommand;
-import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.MedConContainsKeywordsPredicate;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
 
-import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import seedu.address.logic.commands.FindMedConCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
 
 /**
  * Parses input arguments and creates a new FindMedConCommand object.

--- a/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindMedConCommandParser.java
@@ -3,7 +3,9 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.FindMedConCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedConContainsKeywordsPredicate;
@@ -12,21 +14,24 @@ import seedu.address.model.person.MedConContainsKeywordsPredicate;
  * Parses input arguments and creates a new FindMedConCommand object.
  */
 public class FindMedConCommandParser implements Parser<FindMedConCommand> {
+    private static final Logger logger = LogsCenter.getLogger(FindMedConCommandParser.class);
     /**
-     * Parses the given {@code String} of arguments in the context of the ListMedConCommand
-     * and returns a ListMedConCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the FindMedConCommand
+     * and returns a FindMedConCommand object for execution.
      *
      * @throws ParseException if the user input does not conform the expected format.
      */
     public FindMedConCommand parse(String args) throws ParseException {
         String trimmedArgs = args.trim();
         if (trimmedArgs.isEmpty()) {
+            logger.warning("No keywords provided for FindMedConCommand");
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindMedConCommand.MESSAGE_USAGE));
         }
 
         String[] medConKeywords = trimmedArgs.split("\\s+");
         MedConContainsKeywordsPredicate predicate = new MedConContainsKeywordsPredicate(Arrays.asList(medConKeywords));
+        logger.info("Successfully parsed the keywords for FindMedConCommand: " + Arrays.toString(medConKeywords));
         return new FindMedConCommand(predicate);
     }
 }

--- a/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.person;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+/**
+ * Tests that a {@code Person}'s {@code MedCon} matches any of the keywords given.
+ */
+public class MedConContainsKeywordsPredicate implements Predicate<Person> {
+
+    private final List<String> keywords;
+
+    public MedConContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return keywords.stream()
+                .anyMatch(keyword -> person.getMedCons().stream()
+                .anyMatch(medCon -> StringUtil.containsWordIgnoreCase(medCon.value, keyword)));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof MedConContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        MedConContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (MedConContainsKeywordsPredicate) other;
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
@@ -19,9 +19,9 @@ public class MedConContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
-        return keywords.stream()
-                .anyMatch(keyword -> person.getMedCons().stream()
-                .anyMatch(medCon -> StringUtil.containsWordIgnoreCase(medCon.value, keyword)));
+        return person.getMedCons().stream()
+                                  .anyMatch(medCon -> keywords.stream()
+                                  .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(medCon.value, keyword)));
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/MedConContainsKeywordsPredicate.java
@@ -35,8 +35,8 @@ public class MedConContainsKeywordsPredicate implements Predicate<Person> {
             return false;
         }
 
-        MedConContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (MedConContainsKeywordsPredicate) other;
-        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+        MedConContainsKeywordsPredicate otherMedConContainsKeywordsPredicate = (MedConContainsKeywordsPredicate) other;
+        return keywords.equals(otherMedConContainsKeywordsPredicate.keywords);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -50,7 +50,7 @@ public class SampleDataUtil {
                        getTagSet("colleagues", "friends"),
                        new Priority(),
                        getAppointmentSet("Orthopedic:2024-12-01:1200-1300", "Physio:2024-12-01:1500-1600"),
-                    getMedConSet("arthritis, scoliosis")
+                    getMedConSet("arthritis", "scoliosis")
             ),
             new Person(new Name("Charlotte Oliveiro"),
                        new Phone("93210283"),
@@ -76,7 +76,7 @@ public class SampleDataUtil {
                        getAppointmentSet("OT:2025-01-12:1000-1300",
                                          "PT:2025-02-02:1200-1300",
                                          "Consult:2025-02-20:1400-1430"),
-                       getMedConSet("presley syndrome, lung cancer, arthritis")
+                       getMedConSet("presley syndrome", "lung cancer", "arthritis")
             ),
             new Person(new Name("Irfan Ibrahim"),
                        new Phone("92492021"),

--- a/src/test/java/seedu/address/logic/commands/FindMedConCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindMedConCommandTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
@@ -79,6 +80,14 @@ public class FindMedConCommandTest {
         FindMedConCommand command = new FindMedConCommand(predicate);
         expectedModel.updateFilteredPersonList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void toStringMethod() {
+        MedConContainsKeywordsPredicate predicate = preparePredicate("diabetes");
+        FindMedConCommand findCommand = new FindMedConCommand(predicate);
+        String expected = FindMedConCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
+        assertEquals(expected, findCommand.toString());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/FindMedConCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindMedConCommandTest.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code FindMedConCommand}.
+ */
+public class FindMedConCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("diabetes");
+        List<String> secondPredicateKeywordList = Arrays.asList("diabetes", "cancer");
+
+        MedConContainsKeywordsPredicate firstPredicate =
+                new MedConContainsKeywordsPredicate(firstPredicateKeywordList);
+        MedConContainsKeywordsPredicate secondPredicate =
+                new MedConContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        FindMedConCommand findMedConFirstCommand = new FindMedConCommand(firstPredicate);
+        FindMedConCommand findMedConSecondCommand = new FindMedConCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(findMedConFirstCommand.equals(findMedConFirstCommand));
+
+        // same values -> returns true
+        FindMedConCommand findMedConFirstCommandCopy = new FindMedConCommand(firstPredicate);
+        assertTrue(findMedConFirstCommand.equals(findMedConFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(findMedConFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(findMedConFirstCommand.equals(null));
+
+        // different predicate -> returns false
+        assertFalse(findMedConFirstCommand.equals(findMedConSecondCommand));
+    }
+
+    @Test
+    public void execute_zeroKeywords_noMedConFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
+        MedConContainsKeywordsPredicate predicate = preparePredicate(" ");
+        FindMedConCommand command = new FindMedConCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_multipleKeywords_multipleMedConFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
+        MedConContainsKeywordsPredicate predicate = preparePredicate("diabetes cancer scoliosis");
+        FindMedConCommand command = new FindMedConCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_singleKeyword_multipleMedConFound() {
+        String expectedMessage = String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, 2);
+        MedConContainsKeywordsPredicate predicate = preparePredicate("cancer");
+        FindMedConCommand command = new FindMedConCommand(predicate);
+        expectedModel.updateFilteredPersonList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code MedConContainsKeywordsPredicate}.
+     */
+    private MedConContainsKeywordsPredicate preparePredicate(String userInput) {
+        return new MedConContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -27,10 +27,12 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.FindMedConCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.AppointmentExistsPredicate;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.NricMatchesPredicate;
@@ -120,6 +122,14 @@ public class AddressBookParserTest {
     public void parseCommand_list() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+    }
+
+    @Test
+    public void parseCommand_findMedCon() throws Exception {
+        List<String> keywords = Arrays.asList("foo", "bar", "baz");
+        FindMedConCommand command = (FindMedConCommand) parser.parseCommand(
+                FindMedConCommand.COMMAND_WORD + " " + String.join(" ", keywords));
+        assertEquals(new FindMedConCommand(new MedConContainsKeywordsPredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindMedConCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindMedConCommandParserTest.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FindMedConCommand;
+import seedu.address.model.person.MedConContainsKeywordsPredicate;
+
+public class FindMedConCommandParserTest {
+    private FindMedConCommandParser parser = new FindMedConCommandParser();
+
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                FindMedConCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_validArgs_returnsFindMedConCommand() {
+        MedConContainsKeywordsPredicate predicate = new MedConContainsKeywordsPredicate(Arrays.asList("myopia", "flu"));
+        // no leading and trailing whitespaces
+        FindMedConCommand expectedFindMedConCommand = new FindMedConCommand(predicate);
+        assertParseSuccess(parser, "myopia flu", expectedFindMedConCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " \n myopia \n \t flu  \t", expectedFindMedConCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/person/MedConContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MedConContainsKeywordsPredicateTest.java
@@ -1,14 +1,18 @@
 package seedu.address.model.person;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import org.junit.jupiter.api.Test;
-import seedu.address.testutil.PersonBuilder;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.PersonBuilder;
+
+
 
 public class MedConContainsKeywordsPredicateTest {
     public void equals() {
@@ -85,8 +89,8 @@ public class MedConContainsKeywordsPredicateTest {
     public void toStringMethod() {
         List<String> keywords = List.of("diabetes", "hypertension");
         MedConContainsKeywordsPredicate predicate = new MedConContainsKeywordsPredicate(keywords);
-        String expectedString = MedConContainsKeywordsPredicate.class.getCanonicalName() +
-                "{keywords=" + keywords + "}";
-        assertTrue(predicate.toString().equals(expectedString));
+        String expectedString = MedConContainsKeywordsPredicate.class.getCanonicalName()
+                + "{keywords=" + keywords + "}";
+        assertEquals(expectedString, predicate.toString());
     }
 }

--- a/src/test/java/seedu/address/model/person/MedConContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/address/model/person/MedConContainsKeywordsPredicateTest.java
@@ -1,0 +1,92 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.testutil.PersonBuilder;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class MedConContainsKeywordsPredicateTest {
+    public void equals() {
+        List<String> firstPredicateKeywordList = Collections.singletonList("first");
+        List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
+
+        MedConContainsKeywordsPredicate firstPredicate =
+                new MedConContainsKeywordsPredicate(firstPredicateKeywordList);
+        MedConContainsKeywordsPredicate secondPredicate =
+                new MedConContainsKeywordsPredicate(secondPredicateKeywordList);
+
+        //same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        //same values -> returns true
+        MedConContainsKeywordsPredicate firstPredicateCopy =
+                new MedConContainsKeywordsPredicate(firstPredicateKeywordList);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        //different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        //null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        //different medical conditions -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_medConContainsKeywords_returnsTrue() {
+        Person firstPersonToTest = new PersonBuilder().withMedCons("diabetes", "lung cancer").build();
+        Person secondPersonToTest = new PersonBuilder().withMedCons("lung cancer").build();
+        //One keyword
+        MedConContainsKeywordsPredicate predicate =
+                new MedConContainsKeywordsPredicate(Collections.singletonList("diabetes"));
+        assertTrue(predicate.test(firstPersonToTest));
+
+        //Multiple keywords
+        predicate = new MedConContainsKeywordsPredicate(Arrays.asList("diabetes", "cancer"));
+        assertTrue(predicate.test(secondPersonToTest));
+
+        //Only one matching keyword
+        predicate = new MedConContainsKeywordsPredicate(Arrays.asList("diabetes", "hypertension"));
+        assertTrue(predicate.test(firstPersonToTest));
+
+        //Mixed-case keywords
+        predicate = new MedConContainsKeywordsPredicate(Arrays.asList("DiAbEtEs", "CaNcEr"));
+        assertTrue(predicate.test(firstPersonToTest));
+    }
+
+    @Test
+    public void test_medConDoesNotContainKeywords_returnsFalse() {
+        Person firstPersonToTest = new PersonBuilder().withMedCons("diabetes", "hypertension").build();
+        Person secondPersonToTest = new PersonBuilder().withName("Raj").withPhone("92345678")
+                .withNric("S2345678A").withEmail("raj@email.com")
+                .withAddress("123, Jurong West Ave 6, #08-111").withMedCons("insomnia", "diabetes").build();
+        //Zero keywords
+        MedConContainsKeywordsPredicate predicate =
+                new MedConContainsKeywordsPredicate(Collections.emptyList());
+        assertFalse(predicate.test(firstPersonToTest));
+
+        //Non-matching keyword
+        predicate = new MedConContainsKeywordsPredicate(Arrays.asList("cancer"));
+        assertFalse(predicate.test(firstPersonToTest));
+
+        //Keywords match name, nric, phone, email, but does not match medical conditions
+        predicate = new MedConContainsKeywordsPredicate(Arrays.asList("Raj", "92345678", "raj@email.com",
+                "S2345678A"));
+        assertFalse(predicate.test(secondPersonToTest));
+    }
+
+    @Test
+    public void toStringMethod() {
+        List<String> keywords = List.of("diabetes", "hypertension");
+        MedConContainsKeywordsPredicate predicate = new MedConContainsKeywordsPredicate(keywords);
+        String expectedString = MedConContainsKeywordsPredicate.class.getCanonicalName() +
+                "{keywords=" + keywords + "}";
+        assertTrue(predicate.toString().equals(expectedString));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -40,14 +40,16 @@ public class TypicalPersons {
             .withAddress("311, Clementi Ave 2, #02-25")
             .withEmail("johnd@example.com").withPhone("98765432")
             .withTags("owesMoney", "friends")
+            .withMedCons("Lung Cancer", "Diabetes")
             .build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withNric("S1234167F").withDateOfBirth("2000-01-05").withGender("M")
-            .withEmail("heinz@example.com").withAddress("wall street")
+            .withEmail("heinz@example.com").withAddress("wall street").withMedCons("Arthritis", "Scoliosis", "Myopia")
             .build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")
             .withNric("T0234567B").withDateOfBirth("2005-01-01").withGender("M")
             .withEmail("cornelia@example.com").withAddress("10th street").withTags("friends")
+            .withMedCons("Skin Cancer", "Diabetes")
             .build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withNric("T0234567F").withDateOfBirth("2001-01-01").withGender("F")


### PR DESCRIPTION
fixes #99 

Implemented `findMedCon` command for users to find patients based on their medical conditions.

Command Format: `findMedCon KEYWORD [MORE_KEYWORDS]`

Example: `findMedCon diabetes cancer`
Expected output: Will find patients with medical conditions that contain either `diabetes` or `cancer`

Note: The given keyword must be a 'full word' (e.g. 'cancer') and not 'partial words' (e.g. 'canc')

---

Additionally, I have changed the `format` method in `Messages` class such that all person details will be displayed 
vertically, so that they can scroll downwards to view each parameters, and parameters that are stored as a `Set` will have their items printed with a comma between them

Example:

After using `delete` command, the Deleted Person info will be displayed,
![image](https://github.com/user-attachments/assets/4c6fbe60-e784-40d1-8141-58079ea956f8)