### PR TITLE
Rename tag class to allergy class

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -1,0 +1,92 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.PriorityCommand.PATIENT_DOES_NOT_EXIST;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Command to add a tag to a patient in the address book.
+ */
+public class AddAllergyCommand extends Command {
+
+    public static final String COMMAND_WORD = "addAllergy";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds allergy to the patient in the address book. "
+            + "Parameters: NRIC (must be a valid NRIC in the system) "
+            + "[" + PREFIX_TAG + "Allergy]...\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NRIC + "S1234567A "
+            + PREFIX_TAG + "Insulin "
+            + PREFIX_TAG + "Diabetes";
+
+    public static final String MESSAGE_SUCCESS = "New tag added: %1$s";
+    public static final String MESSAGE_DUPLICATE_TAG = "This allergy already exists in the address book %1$s";
+    public static final String MESSAGE_CONSTRAINT = "Allergy should be alphanumeric "
+            + "and not exceed 30 characters long. \n%1$s";
+    private final Nric nric;
+    private final Set<Tag> allergies;
+
+    /**
+     * Creates an AddAllergyCommand to add the specified {@code Tag} to the patient with the specified {@code Nric}.
+     *
+     * @param nric The NRIC of the patient to add the tag to.
+     * @param allergies The allergies to be added to the patient.
+     */
+    public AddAllergyCommand(Nric nric, Set<Tag> allergies) {
+        requireAllNonNull(nric, allergies);
+        this.nric = nric;
+        this.allergies = allergies;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        List<Person> lastShownList = model.getFilteredPersonList();
+        for (Person person : lastShownList) {
+            if (person.getNric().equals(this.nric)) {
+                Set<Tag> updatedallergieset = new HashSet<>(person.getTags());
+                // check for duplicates
+                for (Tag tag : allergies) {
+                    if (!updatedallergieset.add(tag)) {
+                        throw new CommandException(String.format(MESSAGE_DUPLICATE_TAG, tag.toString()));
+                    }
+                }
+                Person editedPerson = new Person(
+                        person.getName(), person.getPhone(), person.getEmail(),
+                        person.getNric(), person.getAddress(), person.getDateOfBirth(),
+                        person.getGender(), updatedallergieset, person.getPriority(), person.getAppointments(),
+                        person.getMedCons());
+                model.setPerson(person, editedPerson);
+                model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+                return new CommandResult(String.format(MESSAGE_SUCCESS, allergies));
+            }
+        }
+        throw new CommandException(PATIENT_DOES_NOT_EXIST);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddAllergyCommand)) {
+            return false;
+        }
+
+        AddAllergyCommand otherAddAllergyCommand = (AddAllergyCommand) other;
+        return nric.equals(otherAddAllergyCommand.nric)
+                && allergies.equals(otherAddAllergyCommand.allergies);
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -27,8 +27,8 @@ public class AddAllergyCommand extends Command {
             + "[" + PREFIX_TAG + "Allergy]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A "
-            + PREFIX_TAG + "Insulin "
-            + PREFIX_TAG + "Diabetes";
+            + PREFIX_TAG + "Pollen "
+            + PREFIX_TAG + "Peanut";
 
     public static final String MESSAGE_SUCCESS = "New tag added: %1$s";
     public static final String MESSAGE_DUPLICATE_TAG = "This allergy already exists in the address book %1$s";

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -43,9 +43,7 @@ public class AddCommand extends Command {
             + PREFIX_GENDER + "M "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
-            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
-            + PREFIX_TAG + "Peanuts "
-            + PREFIX_TAG + "Insulin";
+            + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 ";
 
     public static final String MESSAGE_SUCCESS = "New patient added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This patient already exists in the address book";

--- a/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
@@ -1,0 +1,59 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.Set;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddAllergyCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Nric;
+import seedu.address.model.tag.Tag;
+
+/**
+ * Parses input arguments and creates a new AddAllergyCommand object
+ */
+public class AddAllergyCommandParser implements Parser<AddAllergyCommand> {
+    private static final Logger logger = LogsCenter.getLogger(AddCommandParser.class);
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddAllergyCommand
+     * and returns an AddAllergyCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format.
+     */
+    public AddAllergyCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_TAG);
+
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_TAG)
+                || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddAllergyCommand.MESSAGE_USAGE));
+        }
+        try {
+            Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+            Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+
+            logger.info("Successfully parsed nric for AddAllergyCommand: " + nric);
+            logger.info("Successfully parsed tags for AddAllergyCommand: " + tagList);
+
+            return new AddAllergyCommand(nric, tagList);
+        } catch (ParseException pe) {
+            logger.warning("Unable to parse the NRIC or tags for FindNricCommand: " + args);
+            throw new ParseException(
+                    String.format(AddAllergyCommand.MESSAGE_CONSTRAINT, AddAllergyCommand.MESSAGE_USAGE), pe);
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+}

--- a/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
@@ -35,12 +35,12 @@ public class AddAllergyCommandParser implements Parser<AddAllergyCommand> {
         }
         try {
             Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
-            Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+            Set<Tag> Allergies = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
             logger.info("Successfully parsed nric for AddAllergyCommand: " + nric);
-            logger.info("Successfully parsed tags for AddAllergyCommand: " + tagList);
+            logger.info("Successfully parsed tags for AddAllergyCommand: " + Allergies);
 
-            return new AddAllergyCommand(nric, tagList);
+            return new AddAllergyCommand(nric, Allergies);
         } catch (ParseException pe) {
             logger.warning("Unable to parse the NRIC or tags for FindNricCommand: " + args);
             throw new ParseException(

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -8,9 +8,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_GENDER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Stream;
@@ -44,7 +44,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     public AddCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_NRIC, PREFIX_DOB, PREFIX_GENDER,
-                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+                        PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_NRIC, PREFIX_DOB, PREFIX_GENDER,
                 PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
@@ -61,7 +61,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Phone phone = ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get());
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
-        Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Set<Tag> tagList = new HashSet<>();
         Set<Appointment> appointmentList = Collections.emptySet();
         Set<MedCon> medConList = Collections.emptySet();
         Priority priority = new Priority();

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -8,6 +8,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.commands.AddAllergyCommand;
 import seedu.address.logic.commands.AddApptCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddMedConCommand;
@@ -92,6 +93,9 @@ public class AddressBookParser {
 
         case AddMedConCommand.COMMAND_WORD:
             return new AddMedConCommandParser().parse(arguments);
+
+        case AddAllergyCommand.COMMAND_WORD:
+            return new AddAllergyCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/tag/Tag.java
+++ b/src/main/java/seedu/address/model/tag/Tag.java
@@ -9,8 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Tag {
 
-    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric";
-    public static final String VALIDATION_REGEX = "\\p{Alnum}+";
+    public static final String MESSAGE_CONSTRAINTS = "Tags names should be alphanumeric and not exceed 30 characters";
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+(\\s\\p{Alnum}+)*";
 
     public final String tagName;
 
@@ -29,7 +29,7 @@ public class Tag {
      * Returns true if a given string is a valid tag name.
      */
     public static boolean isValidTagName(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(VALIDATION_REGEX) && test.length() <= 30;
     }
 
     @Override
@@ -56,7 +56,7 @@ public class Tag {
      * Format state as text for viewing.
      */
     public String toString() {
-        return '[' + tagName + ']';
+        return tagName;
     }
 
 }

--- a/src/test/java/seedu/address/logic/commands/AddAllergyCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAllergyCommandTest.java
@@ -1,0 +1,86 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+import static seedu.address.testutil.TypicalPersons.BOB;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.person.Nric;
+import seedu.address.model.person.NricMatchesPredicate;
+import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
+
+public class AddAllergyCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @Test
+    public void constructor_nullNricAndNullAllergies_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new AddAllergyCommand(null, null));
+    }
+
+    @Test
+    public void execute_noNricFound() throws Exception {
+        // ensures CommandException is thrown when provided with Nric that is not in addressbook
+        Nric nric = new Nric("T1111111F");
+        Set<Tag> tags = ALICE.getTags();
+        AddAllergyCommand command = new AddAllergyCommand(nric, tags);
+        assertThrows(CommandException.class, () -> command.execute(model));
+    }
+
+    @Test
+    public void execute_addAllergy_success() throws Exception {
+        // ensures CommandException is thrown when provided with Nric that is not in addressbook
+        Nric nric = ALICE.getNric();
+        String allergy = "Peanut allergy";
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag(allergy));
+
+        Set<Tag> expectedTags = new HashSet<>();
+        expectedTags.add(new Tag(allergy));
+        expectedTags.addAll(ALICE.getTags());
+
+        AddAllergyCommand command = new AddAllergyCommand(nric, tags);
+        command.execute(model);
+        Person alice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
+                .orElse(null);
+        assertEquals(expectedTags, alice.getTags());
+    }
+
+    @Test
+    public void equals() {
+        Nric aliceNric = ALICE.getNric();
+        Set<Tag> aliceTags = ALICE.getTags();
+        Nric bobNric = BOB.getNric();
+        Set<Tag> bobTags = BOB.getTags();
+        AddAllergyCommand addAliceAllergyCommand = new AddAllergyCommand(aliceNric, aliceTags);
+        AddAllergyCommand addBobCommand = new AddAllergyCommand(bobNric, bobTags);
+        // same object -> returns true
+        assertTrue(addAliceAllergyCommand.equals(addAliceAllergyCommand));
+
+        // same values -> returns true
+        AddAllergyCommand addAliceAllergyCommandCopy = new AddAllergyCommand(aliceNric, aliceTags);
+        assertTrue(addAliceAllergyCommand.equals(addAliceAllergyCommandCopy));
+
+        // different types -> returns false
+        assertFalse(addAliceAllergyCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(addAliceAllergyCommand.equals(null));
+
+        // different person -> returns false
+        assertFalse(addAliceAllergyCommand.equals(addBobCommand));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddAllergyCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddAllergyCommandParserTest.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalPersons.ALICE;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.AddAllergyCommand;
+import seedu.address.model.person.Nric;
+import seedu.address.model.tag.Tag;
+
+public class AddAllergyCommandParserTest {
+
+    private final AddAllergyCommandParser parser = new AddAllergyCommandParser();
+
+    @Test
+    public void parse_allFieldsValid_success() {
+        Nric aliceNric = ALICE.getNric();
+        String allergy = "Peanut allergy";
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag(allergy));
+        AddAllergyCommand expectedCommand = new AddAllergyCommand(aliceNric, tags);
+        assertParseSuccess(parser, " " + PREFIX_NRIC + aliceNric.value
+                + " " + PREFIX_TAG + allergy, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingFields_failure() {
+        Nric aliceNric = ALICE.getNric();
+        String allergy = "Peanut allergy";
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag(allergy));
+        AddAllergyCommand expectedCommand = new AddAllergyCommand(aliceNric, tags);
+        assertParseFailure(parser, " " + PREFIX_TAG + allergy,
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddAllergyCommand.MESSAGE_USAGE));
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddCommandParserTest.java
@@ -17,7 +17,6 @@ import static seedu.address.logic.commands.CommandTestUtil.INVALID_GENDER_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
-import static seedu.address.logic.commands.CommandTestUtil.INVALID_TAG_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.NRIC_DESC_AMY;
@@ -26,8 +25,6 @@ import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.PHONE_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_NON_EMPTY;
 import static seedu.address.logic.commands.CommandTestUtil.PREAMBLE_WHITESPACE;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DOB_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
@@ -35,8 +32,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_GENDER_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DOB;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
@@ -46,7 +41,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
-import static seedu.address.testutil.TypicalPersons.AMY;
 import static seedu.address.testutil.TypicalPersons.BOB;
 
 import org.junit.jupiter.api.Test;
@@ -61,7 +55,6 @@ import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 import seedu.address.testutil.PersonBuilder;
 
 public class AddCommandParserTest {
@@ -69,27 +62,18 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Person expectedPerson = new PersonBuilder(BOB).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_FRIEND,
+                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB + ADDRESS_DESC_BOB,
                 new AddCommand(expectedPerson));
-
-
-        // multiple tags - all accepted
-        Person expectedPersonMultipleTags = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND, VALID_TAG_HUSBAND)
-                .build();
-        assertParseSuccess(parser,
-                NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                        + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                        + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, new AddCommand(expectedPersonMultipleTags));
     }
 
     @Test
     public void parse_repeatedNonTagValue_failure() {
         String validExpectedPersonString = NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + NRIC_DESC_BOB
-                + DOB_DESC_BOB + GENDER_DESC_BOB + ADDRESS_DESC_BOB + TAG_DESC_FRIEND;
+                + DOB_DESC_BOB + GENDER_DESC_BOB + ADDRESS_DESC_BOB;
 
         // multiple names
         assertParseFailure(parser, NAME_DESC_AMY + validExpectedPersonString,
@@ -196,15 +180,6 @@ public class AddCommandParserTest {
     }
 
     @Test
-    public void parse_optionalFieldsMissing_success() {
-        // zero tags
-        Person expectedPerson = new PersonBuilder(AMY).withTags().build();
-        assertParseSuccess(parser, NAME_DESC_AMY + PHONE_DESC_AMY + EMAIL_DESC_AMY + ADDRESS_DESC_AMY
-                + NRIC_DESC_AMY + DOB_DESC_AMY + GENDER_DESC_AMY,
-                new AddCommand(expectedPerson));
-    }
-
-    @Test
     public void parse_compulsoryFieldMissing_failure() {
         String expectedMessage = String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE);
 
@@ -245,37 +220,27 @@ public class AddCommandParserTest {
     public void parse_invalidValue_failure() {
         // invalid name
         assertParseFailure(parser, INVALID_NAME_DESC + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB + TAG_DESC_HUSBAND
-                + TAG_DESC_FRIEND, Name.MESSAGE_CONSTRAINTS);
+                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB, Name.MESSAGE_CONSTRAINTS);
 
         // invalid phone
         assertParseFailure(parser, NAME_DESC_BOB + INVALID_PHONE_DESC + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Phone.MESSAGE_CONSTRAINTS);
+                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB, Phone.MESSAGE_CONSTRAINTS);
 
         // invalid email
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + INVALID_EMAIL_DESC + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Email.MESSAGE_CONSTRAINTS);
+                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB, Email.MESSAGE_CONSTRAINTS);
 
         // invalid address
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + INVALID_ADDRESS_DESC
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND, Address.MESSAGE_CONSTRAINTS);
-
-        // invalid tag
-        assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                + INVALID_TAG_DESC + VALID_TAG_FRIEND, Tag.MESSAGE_CONSTRAINTS);
+                + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB, Address.MESSAGE_CONSTRAINTS);
 
         // invalid nric
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + INVALID_NRIC_DESC + DOB_DESC_BOB + GENDER_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
-                Nric.MESSAGE_CONSTRAINTS);
+                + INVALID_NRIC_DESC + DOB_DESC_BOB + GENDER_DESC_BOB, Nric.MESSAGE_CONSTRAINTS);
 
         // invalid date of birth format
         assertParseFailure(parser, NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB + ADDRESS_DESC_BOB
-                + NRIC_DESC_BOB + INVALID_DOB_FORMAT_DESC + GENDER_DESC_BOB + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + NRIC_DESC_BOB + INVALID_DOB_FORMAT_DESC + GENDER_DESC_BOB,
                 DateOfBirth.MESSAGE_CONSTRAINTS_WRONG_FORMAT);
 
         // invalid date of birth value
@@ -293,8 +258,7 @@ public class AddCommandParserTest {
 
         // non-empty preamble
         assertParseFailure(parser, PREAMBLE_NON_EMPTY + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB
-                + TAG_DESC_HUSBAND + TAG_DESC_FRIEND,
+                + ADDRESS_DESC_BOB + NRIC_DESC_BOB + DOB_DESC_BOB + GENDER_DESC_BOB,
                 String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -11,13 +11,18 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_NAM
 import static seedu.address.logic.commands.CommandTestUtil.VALID_APPOINTMENT_TIMEPERIOD_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_DEL_APPT_AMY_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.AddAllergyCommand;
 import seedu.address.logic.commands.AddApptCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.ClearCommand;
@@ -35,6 +40,7 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
+import seedu.address.model.tag.Tag;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -72,6 +78,17 @@ public class AddressBookParserTest {
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + VALID_NRIC_AMY + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
         assertEquals(new EditCommand(new NricMatchesPredicate(new Nric(VALID_NRIC_AMY)), descriptor), command);
+    }
+
+    @Test
+    public void parseCommand_addAllergy() throws Exception {
+        Person person = new PersonBuilder().withNric(VALID_NRIC_AMY).build();
+        AddAllergyCommand command = (AddAllergyCommand) parser.parseCommand(
+                AddAllergyCommand.COMMAND_WORD + " " + PREFIX_NRIC + NRIC_DESC_AMY
+                        + " " + PREFIX_TAG + "Insulin");
+        Set<Tag> tags = new HashSet<>();
+        tags.add(new Tag("Insulin"));
+        assertEquals(new AddAllergyCommand(new Nric(VALID_NRIC_AMY), tags), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -15,7 +15,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_FRIEND;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_TAG_HUSBAND;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -79,7 +78,7 @@ public class TypicalPersons {
             .build();
     public static final Person BOB = new PersonBuilder().withName(VALID_NAME_BOB).withPhone(VALID_PHONE_BOB)
             .withNric(VALID_NRIC_BOB).withDateOfBirth(VALID_DOB_BOB).withGender(VALID_GENDER_BOB)
-            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND)
+            .withEmail(VALID_EMAIL_BOB).withAddress(VALID_ADDRESS_BOB)
             .build();
 
     public static final String KEYWORD_MATCHING_MEIER = "Meier"; // A keyword that matches MEIER


### PR DESCRIPTION
Fixes #83 

Separated tag class with add command, making it a stand-alone function.
The tag command is known as addAllergyCommand.

command format: addAllergy i/VALID NRIC t/VALID TAG

Will add more test case in the future.