### PR TITLE
Bug Fix where Priority is not shown due to background color in GUI

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -85,6 +85,7 @@ public class PersonCard extends UiPart<Region> {
         // Set up the label for priority
         Label priorityLabel = new Label(person.getPriority().priority);
         priorityLabel.getStyleClass().add("priority-label");
+
         // Remove any existing priority styles
         priority.getStyleClass().removeAll("priority-high-bg", "priority-medium-bg",
                 "priority-low-bg", "priority-none-bg");
@@ -108,6 +109,7 @@ public class PersonCard extends UiPart<Region> {
         }
 
         // Add the label to the FlowPane
+        priorityLabel.setStyle("-fx-text-fill: black;");
         priority.getChildren().add(priorityLabel);
 
     }


### PR DESCRIPTION
fixes #112 

As the text was previously white, when Priority is NONE , background for FlowPanel is white, as such white on white resulted in lack of visibility of the Priority Level. A change has been made to change the color of the text in the Label to be black.