### PR TITLE
Bug Fix for potentially Multiple Parameter in PriorityCommandParser

### DIFF
--- a/src/main/java/seedu/address/logic/commands/PriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/PriorityCommand.java
@@ -33,7 +33,7 @@ public class PriorityCommand extends Command {
     public static final String PRIORITY_ASSIGN_SUCCESS = "Assigned priority to Person: %1$s";
     public static final String PATIENT_DOES_NOT_EXIST = "Patient does not exist in contact list";
     public static final String PRIORITY_SET_TO_NONE_SUCCESS = "Priority has been removed from Person: %1$s";
-
+    public static final String MULTIPLE_PARAMETER = "Please input only 1 of each parameter";
     private final Priority priority;
     private final Nric nric;
 

--- a/src/main/java/seedu/address/logic/parser/PriorityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PriorityCommandParser.java
@@ -29,22 +29,14 @@ public class PriorityCommandParser implements Parser<PriorityCommand> {
         String trimmedArgs = args.trim();
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_NRIC, PREFIX_PRIORITY);
-
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_PRIORITY);
         if (!argMultimap.getValue(PREFIX_NRIC).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     PriorityCommand.MESSAGE_USAGE));
         }
-        if (argMultimap.getAllValues(PREFIX_NRIC).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    PriorityCommand.MULTIPLE_PARAMETER));
-        }
         if (!argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     PriorityCommand.MESSAGE_USAGE));
-        }
-        if (argMultimap.getAllValues(PREFIX_PRIORITY).size() > 1) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    PriorityCommand.MULTIPLE_PARAMETER));
         }
 
         String nricStr = argMultimap.getValue(PREFIX_NRIC).orElse("");

--- a/src/main/java/seedu/address/logic/parser/PriorityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/PriorityCommandParser.java
@@ -34,10 +34,17 @@ public class PriorityCommandParser implements Parser<PriorityCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     PriorityCommand.MESSAGE_USAGE));
         }
-
+        if (argMultimap.getAllValues(PREFIX_NRIC).size() > 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    PriorityCommand.MULTIPLE_PARAMETER));
+        }
         if (!argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                     PriorityCommand.MESSAGE_USAGE));
+        }
+        if (argMultimap.getAllValues(PREFIX_PRIORITY).size() > 1) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    PriorityCommand.MULTIPLE_PARAMETER));
         }
 
         String nricStr = argMultimap.getValue(PREFIX_NRIC).orElse("");

--- a/src/test/java/seedu/address/logic/parser/PriorityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PriorityCommandParserTest.java
@@ -80,4 +80,19 @@ public class PriorityCommandParserTest {
         // Priority parameter missing
         assertParseFailure(parser, NRIC_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT, MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_multipleParameter_failure() {
+        // Multiple NRIC input
+        assertParseFailure(parser, NRIC_DESC_AMY + NRIC_DESC_BOB + PRIORITY_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+
+        // Multiple Priority input
+        assertParseFailure(parser, NRIC_DESC_AMY + PRIORITY_DESC_AMY + PRIORITY_DESC_BOB,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+
+        // Multiple NRIC and Priority input
+        assertParseFailure(parser, NRIC_DESC_AMY + NRIC_DESC_BOB + PRIORITY_DESC_AMY
+                + PRIORITY_DESC_BOB, String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/PriorityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/PriorityCommandParserTest.java
@@ -14,11 +14,14 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_BOB;
 import static seedu.address.logic.commands.PriorityCommand.MESSAGE_USAGE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.PriorityCommand;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Priority;
@@ -85,14 +88,14 @@ public class PriorityCommandParserTest {
     public void parse_multipleParameter_failure() {
         // Multiple NRIC input
         assertParseFailure(parser, NRIC_DESC_AMY + NRIC_DESC_BOB + PRIORITY_DESC_AMY,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NRIC));
 
         // Multiple Priority input
         assertParseFailure(parser, NRIC_DESC_AMY + PRIORITY_DESC_AMY + PRIORITY_DESC_BOB,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+                Messages.getErrorMessageForDuplicatePrefixes(PREFIX_PRIORITY));
 
         // Multiple NRIC and Priority input
         assertParseFailure(parser, NRIC_DESC_AMY + NRIC_DESC_BOB + PRIORITY_DESC_AMY
-                + PRIORITY_DESC_BOB, String.format(MESSAGE_INVALID_COMMAND_FORMAT, PriorityCommand.MULTIPLE_PARAMETER));
+                + PRIORITY_DESC_BOB, Messages.getErrorMessageForDuplicatePrefixes(PREFIX_NRIC, PREFIX_PRIORITY));
     }
 }


### PR DESCRIPTION
fixes #121 

Previously there exists a bug where we could do the following

assignPriority i/S1234567A i/S1234567B !/HIGH

Or

assignPriority i/S1234567A !/LOW !/HIGH

OR

assignPriority i/S1234567A i/S1234567B !/LOW !/HIGH


to fix this problem and to only allow 1 of each parameter, a fix has been implemented.
In the parse method in PriorityCommandParser, we add an additional check to ensure only 1 of such parameter has been passed in. Test cases has been implemented as well to accommodate the above changes. Please let me know if there are areas for improvement. Thanks!