### PR TITLE
Fix delete and add medical condition

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
@@ -4,13 +4,13 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.MedCon;
 import seedu.address.model.person.Nric;
+import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -49,25 +49,24 @@ public class AddMedConCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
-        for (Person person : lastShownList) {
-            if (person.getNric().equals(this.nric)) {
-                Set<MedCon> updatedMedConSet = new HashSet<>(person.getMedCons());
-                // check for duplicates
-                for (MedCon medCon : medCons) {
-                    if (!updatedMedConSet.add(medCon)) {
-                        throw new CommandException(String.format(MESSAGE_DUPLICATE_MEDCON, medCon.value));
-                    }
+        Person person = model.fetchPersonIfPresent(new NricMatchesPredicate(nric))
+                .orElseThrow(() -> new CommandException(PATIENT_DOES_NOT_EXIST));
+        if (person.getNric().equals(this.nric)) {
+            Set<MedCon> updatedMedConSet = new HashSet<>(person.getMedCons());
+            // check for duplicates
+            for (MedCon medCon : medCons) {
+                if (!updatedMedConSet.add(medCon)) {
+                    throw new CommandException(String.format(MESSAGE_DUPLICATE_MEDCON, medCon.value));
                 }
-                Person editedPerson = new Person(
-                        person.getName(), person.getPhone(), person.getEmail(),
-                        person.getNric(), person.getAddress(), person.getDateOfBirth(),
-                        person.getGender(), person.getAllergies(), person.getPriority(), person.getAppointments(),
-                        updatedMedConSet);
-                model.setPerson(person, editedPerson);
-                model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-                return new CommandResult(generateSuccessMessage(editedPerson));
             }
+            Person editedPerson = new Person(
+                    person.getName(), person.getPhone(), person.getEmail(),
+                    person.getNric(), person.getAddress(), person.getDateOfBirth(),
+                    person.getGender(), person.getAllergies(), person.getPriority(), person.getAppointments(),
+                    updatedMedConSet);
+            model.setPerson(person, editedPerson);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(generateSuccessMessage(editedPerson));
         }
         throw new CommandException(PATIENT_DOES_NOT_EXIST);
     }

--- a/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
@@ -4,13 +4,13 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.MedCon;
 import seedu.address.model.person.Nric;
+import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 
 /**
@@ -49,32 +49,30 @@ public class DelMedConCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
+        Person person = model.fetchPersonIfPresent(new NricMatchesPredicate(nric))
+                .orElseThrow(() -> new CommandException(PATIENT_DOES_NOT_EXIST));
 
-        for (Person person : lastShownList) {
-            if (person.getNric().equals(this.nric)) {
-                Set<MedCon> updatedMedConSet = new HashSet<>(person.getMedCons());
+        if (person.getNric().equals(this.nric)) {
+            Set<MedCon> updatedMedConSet = new HashSet<>(person.getMedCons());
 
-                // check if the medical conditions to delete exist in the current set
-                for (MedCon medCon : medCons) {
-                    if (!updatedMedConSet.remove(medCon)) {
-                        throw new CommandException(String.format(MESSAGE_MEDCON_NOT_FOUND, medCon.value));
-                    }
+            // check if the medical conditions to delete exist in the current set
+            for (MedCon medCon : medCons) {
+                if (!updatedMedConSet.remove(medCon)) {
+                    throw new CommandException(String.format(MESSAGE_MEDCON_NOT_FOUND, medCon.value));
                 }
-
-                // create an edited person with the updated medical conditions
-                Person editedPerson = new Person(
-                        person.getName(), person.getPhone(), person.getEmail(),
-                        person.getNric(), person.getAddress(), person.getDateOfBirth(),
-                        person.getGender(), person.getAllergies(), person.getPriority(), person.getAppointments(),
-                        updatedMedConSet);
-
-                model.setPerson(person, editedPerson);
-                model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
-                return new CommandResult(generateSuccessMessage(editedPerson));
             }
-        }
 
+            // create an edited person with the updated medical conditions
+            Person editedPerson = new Person(
+                    person.getName(), person.getPhone(), person.getEmail(),
+                    person.getNric(), person.getAddress(), person.getDateOfBirth(),
+                    person.getGender(), person.getAllergies(), person.getPriority(), person.getAppointments(),
+                    updatedMedConSet);
+
+            model.setPerson(person, editedPerson);
+            model.updateFilteredPersonList(Model.PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(generateSuccessMessage(editedPerson));
+        }
         throw new CommandException(PATIENT_DOES_NOT_EXIST);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
@@ -58,5 +58,4 @@ public class AddAllergyCommandParser implements Parser<AddAllergyCommand> {
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedConCommandParser.java
@@ -8,6 +8,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.HashSet;
 import java.util.Set;
+import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddMedConCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -31,7 +32,7 @@ public class AddMedConCommandParser implements Parser<AddMedConCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_MEDCON);
 
         // Check if NRIC is provided
-        if (!argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
         }
 
@@ -52,5 +53,13 @@ public class AddMedConCommandParser implements Parser<AddMedConCommand> {
 
         return new AddMedConCommand(nric, medCons);
 
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/DelMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DelMedConCommandParser.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
+import java.util.stream.Stream;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.DelMedConCommand;
@@ -36,7 +37,7 @@ public class DelMedConCommandParser implements Parser<DelMedConCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_MEDCON);
 
         // Check if NRIC is provided
-        if (!argMultimap.getValue(PREFIX_NRIC).isPresent()) {
+        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
             logger.warning("NRIC not provided in DelMedConCommand arguments.");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DelMedConCommand.MESSAGE_USAGE));
         }
@@ -58,5 +59,13 @@ public class DelMedConCommandParser implements Parser<DelMedConCommand> {
         }
 
         return new DelMedConCommand(nric, medCons);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddMedConCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMedConCommandParserTest.java
@@ -16,7 +16,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -51,15 +50,6 @@ public class AddMedConCommandParserTest {
                 multipleMedConsAmy);
         assertParseSuccess(parser, NRIC_DESC_AMY + MEDCON_DESC_AMY + MEDCON_DESC_BOB,
                 expectedCommandForAmyMultiple);
-
-        // For Amy without MedCon (MedCon is optional)
-        Set<MedCon> noMedCons = Collections.emptySet();
-        AddMedConCommand expectedCommandForAmyNoMedCon = new AddMedConCommand(new Nric(VALID_NRIC_AMY), noMedCons);
-        assertParseSuccess(parser, NRIC_DESC_AMY, expectedCommandForAmyNoMedCon);
-
-        // For Bob without MedCon (MedCon is optional)
-        AddMedConCommand expectedCommandForBobNoMedCon = new AddMedConCommand(new Nric(VALID_NRIC_BOB), noMedCons);
-        assertParseSuccess(parser, NRIC_DESC_BOB, expectedCommandForBobNoMedCon);
     }
 
     @Test
@@ -81,6 +71,10 @@ public class AddMedConCommandParserTest {
 
         // NRIC parameter missing
         assertParseFailure(parser, MEDCON_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                AddMedConCommand.MESSAGE_USAGE));
+
+        // MedCon parameter missing
+        assertParseFailure(parser, NRIC_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 AddMedConCommand.MESSAGE_USAGE));
     }
 

--- a/src/test/java/seedu/address/logic/parser/DelMedConCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DelMedConCommandParserTest.java
@@ -15,7 +15,6 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -42,10 +41,6 @@ public class DelMedConCommandParserTest {
         DelMedConCommand expectedCommandForBob = new DelMedConCommand(new Nric(VALID_NRIC_BOB), medConsBob);
         assertParseSuccess(parser, NRIC_DESC_BOB + MEDCON_DESC_BOB, expectedCommandForBob);
 
-        // For Amy without MedCon (MedCon is optional)
-        Set<MedCon> noMedCons = Collections.emptySet();
-        DelMedConCommand expectedCommandForAmyNoMedCon = new DelMedConCommand(new Nric(VALID_NRIC_AMY), noMedCons);
-        assertParseSuccess(parser, NRIC_DESC_AMY, expectedCommandForAmyNoMedCon);
     }
 
     @Test


### PR DESCRIPTION
fixes #133 #136 

It will fix the delete empty parameter bug. Empty fields will now display an error

add medical condition can now be added even after filtering person list and will display an error when nric field is empty.