### PR TITLE
Refactor and Enhance Medical Condition Commands and Parsers

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -12,6 +12,7 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
+    public static final String MESSAGE_EMPTY_FIELD = "field should not by empty";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_PERSON_NRIC_NOT_FOUND = "The patient with the specified NRIC does not exist";
@@ -19,7 +20,7 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_CONSTRAINTS_LENGTH =
-            "Medical condition length exceeds the limit of 45 characters";
+            "length should not exceed the limit of 30 characters";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/address/logic/parser/AddMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddMedConCommandParser.java
@@ -1,15 +1,15 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDCON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 
 import java.util.HashSet;
 import java.util.Set;
-import java.util.stream.Stream;
+import java.util.logging.Logger;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddMedConCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.MedCon;
@@ -19,6 +19,7 @@ import seedu.address.model.person.Nric;
  * Parses user input for the {@link AddMedConCommand} and creates a new instance of it.
  */
 public class AddMedConCommandParser implements Parser<AddMedConCommand> {
+    private static final Logger logger = LogsCenter.getLogger(AddMedConCommandParser.class);
     /**
      * Parses the given arguments string and creates a {@link AddMedConCommand} object.
      *
@@ -32,7 +33,8 @@ public class AddMedConCommandParser implements Parser<AddMedConCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_MEDCON);
 
         // Check if NRIC is provided
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.arePrefixesPresent(PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
+            logger.warning("NRIC not provided in AddMedConCommand arguments.");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
         }
 
@@ -45,25 +47,13 @@ public class AddMedConCommandParser implements Parser<AddMedConCommand> {
         // Parse all MedCon values and add them to a set
         Set<MedCon> medCons = new HashSet<>();
         for (String medConStr : argMultimap.getAllValues(PREFIX_MEDCON)) {
-            if (medConStr.isEmpty()) {
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        AddMedConCommand.MESSAGE_USAGE));
-            } else if (medConStr.length() > 45) {
-                throw new ParseException(MESSAGE_CONSTRAINTS_LENGTH);
-            } else {
-                medCons.add(new MedCon(medConStr));
-            }
+            MedCon medCon = ParserUtil.parseMedCon(medConStr);
+            medCons.add(medCon);
         }
 
         return new AddMedConCommand(nric, medCons);
 
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -75,4 +75,14 @@ public class ArgumentMultimap {
             throw new ParseException(Messages.getErrorMessageForDuplicatePrefixes(duplicatedPrefixes));
         }
     }
+
+    /**
+     * Returns true if all of the specified prefixes are present and contain non-empty values.
+     *
+     * @param prefixes The prefixes to check.
+     * @return true if all prefixes are present, false otherwise.
+     */
+    public boolean arePrefixesPresent(Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> this.getValue(prefix).isPresent());
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/DelMedConCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DelMedConCommandParser.java
@@ -1,7 +1,6 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_MEDCON;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
@@ -9,7 +8,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Logger;
-import java.util.stream.Stream;
 
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.DelMedConCommand;
@@ -37,7 +35,7 @@ public class DelMedConCommandParser implements Parser<DelMedConCommand> {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NRIC, PREFIX_MEDCON);
 
         // Check if NRIC is provided
-        if (!arePrefixesPresent(argMultimap, PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
+        if (!argMultimap.arePrefixesPresent(PREFIX_NRIC, PREFIX_MEDCON) || !argMultimap.getPreamble().isEmpty()) {
             logger.warning("NRIC not provided in DelMedConCommand arguments.");
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DelMedConCommand.MESSAGE_USAGE));
         }
@@ -51,26 +49,12 @@ public class DelMedConCommandParser implements Parser<DelMedConCommand> {
         // Parse all MedCon values and add them to a set
         Set<MedCon> medCons = new HashSet<>();
         for (String medConStr : argMultimap.getAllValues(PREFIX_MEDCON)) {
-            if (medConStr.isEmpty()) {
-                logger.warning("Medical condition is empty.");
-                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        DelMedConCommand.MESSAGE_USAGE));
-            } else if (medConStr.length() > 45) {
-                logger.warning("Medical condition exceeds character limit: " + medConStr);
-                throw new ParseException(MESSAGE_CONSTRAINTS_LENGTH);
-            } else {
-                medCons.add(new MedCon(medConStr));
-            }
+            MedCon medCon = ParserUtil.parseMedCon(medConStr);
+            medCons.add(medCon);
         }
 
         return new DelMedConCommand(nric, medCons);
     }
 
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
-    }
+
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -249,17 +251,20 @@ public class ParserUtil {
     }
 
     /**
-     * Parses a string representing a medical condition and returns a {@link MedCon} object.
+     * Parses and validates the given medical condition string.
      *
-     * @param medConStr the string representing the medical condition to be parsed.
-     * @return A {@link MedCon} object corresponding to the provided medical condition string.
-     * @throws ParseException if the provided string does not conform to the expected
-     *         format or is invalid as per the priority constraints defined in the
-     *         {@link Priority} class.
+     * @param medConStr The medical condition string to parse.
+     * @return A {@code MedCon} object.
+     * @throws ParseException If the medical condition string is invalid.
      */
     public static MedCon parseMedCon(String medConStr) throws ParseException {
-        requireNonNull(medConStr);
-        String trimmedMedCon = medConStr.trim();
-        return new MedCon(trimmedMedCon);
+        if (medConStr.isEmpty()) {
+            throw new ParseException("Medical condition " + MESSAGE_EMPTY_FIELD);
+        } else if (medConStr.length() > 30) {
+            throw new ParseException("Medical condition " + MESSAGE_CONSTRAINTS_LENGTH);
+        } else if (!medConStr.matches(MedCon.VALIDATION_REGEX)) {
+            throw new ParseException("Invalid medical condition format.");
+        }
+        return new MedCon(medConStr);
     }
 }

--- a/src/main/java/seedu/address/model/person/MedCon.java
+++ b/src/main/java/seedu/address/model/person/MedCon.java
@@ -33,8 +33,12 @@ public class MedCon implements Comparable<MedCon> {
      * @return true if the string is not empty and does not exceed 45 characters.
      */
     public static boolean isValidMedCon(String medCon) {
+        if (medCon == null || medCon.isEmpty()) {
+            return false;
+        }
         return medCon.matches(VALIDATION_REGEX) && medCon.length() <= 30;
     }
+
 
     /**
      * Returns the medical condition of the patient.

--- a/src/main/java/seedu/address/model/person/MedCon.java
+++ b/src/main/java/seedu/address/model/person/MedCon.java
@@ -1,14 +1,17 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 
 /**
  * Represents a patient's medical condition in the address book.
- *
  * Guarantees: The priority is immutable and always valid.
  */
 public class MedCon implements Comparable<MedCon> {
 
+    public static final String VALIDATION_REGEX = "\\p{Alnum}+(\\s\\p{Alnum}+)*";
     public final String value;
 
     /**
@@ -18,7 +21,19 @@ public class MedCon implements Comparable<MedCon> {
      */
     public MedCon(String medCon) {
         requireNonNull(medCon);
+        checkArgument(!medCon.isEmpty(), MESSAGE_EMPTY_FIELD);
+        checkArgument(isValidMedCon(medCon), MESSAGE_CONSTRAINTS_LENGTH);
         value = medCon;
+    }
+
+    /**
+     * Returns true if a given string is a valid medical condition name.
+     *
+     * @param medCon the string to be validated
+     * @return true if the string is not empty and does not exceed 45 characters.
+     */
+    public static boolean isValidMedCon(String medCon) {
+        return medCon.matches(VALIDATION_REGEX) && medCon.length() <= 30;
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedMedCon.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedMedCon.java
@@ -1,5 +1,7 @@
 package seedu.address.storage;
 
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -39,6 +41,13 @@ class JsonAdaptedMedCon {
      * @throws IllegalValueException if there were any data constraints violated in the adapted MedCon.
      */
     public MedCon toModelType() throws IllegalValueException {
+        if (medConName == null) {
+            throw new IllegalValueException(String.format("%s cannot be null", MedCon.class.getSimpleName()));
+        }
+        if (!MedCon.isValidMedCon(medConName)) {
+            throw new IllegalValueException(String.format("%s: %s", MedCon.class.getSimpleName(),
+                    MESSAGE_CONSTRAINTS_LENGTH));
+        }
         return new MedCon(medConName);
     }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -108,7 +108,7 @@ public class CommandTestUtil {
             .format(DateTimeFormatter.ofPattern("yyyy-MM-dd")); // DOB in future
     public static final String INVALID_GENDER_DESC = " " + PREFIX_GENDER + "X"; // 'X' not allowed for gender
     public static final String INVALID_MEDCON_DESC = " " + PREFIX_MEDCON
-            + "Pneumonoultramicroscopicsilicovolcanoconiosislolololol"; // longer than 45 characters
+            + "Pneumonoultramicroscopicsilicovolcanoconiosislolololol"; // longer than 30 characters
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses

--- a/src/test/java/seedu/address/logic/parser/AddMedConCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMedConCommandParserTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_MEDCON_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
@@ -22,6 +23,7 @@ import java.util.Set;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.AddMedConCommand;
 import seedu.address.model.person.MedCon;
 import seedu.address.model.person.Nric;
@@ -67,31 +69,28 @@ public class AddMedConCommandParserTest {
     @Test
     public void parse_compulsoryFieldsMissing_failure() {
         // Both NRIC and MedCon missing
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
 
         // NRIC parameter missing
-        assertParseFailure(parser, MEDCON_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, MEDCON_DESC_AMY,
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
 
         // MedCon parameter missing
-        assertParseFailure(parser, NRIC_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, NRIC_DESC_AMY,
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
+
+        // MedCon prefix present, but no value
         assertParseFailure(parser, NRIC_DESC_AMY + " " + PREFIX_MEDCON,
-                String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddMedConCommand.MESSAGE_USAGE));
-
-        // MedCon parameter missing
-        assertParseFailure(parser, NRIC_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                AddMedConCommand.MESSAGE_USAGE));
+                "Medical condition " + MESSAGE_EMPTY_FIELD);
     }
 
-
     @Test
-    public void parse_medConLengthGreaterThan45Characters_failure() {
-        // Medical condition exceeds 45 characters
+    public void parse_medConLengthGreaterThan30Characters_failure() {
+        // Medical condition exceeds 30 characters
         String input = NRIC_DESC_AMY + INVALID_MEDCON_DESC;
 
-        assertParseFailure(parser, input, MESSAGE_CONSTRAINTS_LENGTH);
+        assertParseFailure(parser, input, "Medical condition " + MESSAGE_CONSTRAINTS_LENGTH);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/DelMedConCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DelMedConCommandParserTest.java
@@ -1,7 +1,9 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_MEDCON_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_NRIC_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.MEDCON_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.MEDCON_DESC_BOB;
@@ -57,26 +59,28 @@ public class DelMedConCommandParserTest {
     @Test
     public void parse_compulsoryFieldsMissing_failure() {
         // Both NRIC and MedCon missing
-        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DelMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "",
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DelMedConCommand.MESSAGE_USAGE));
 
         // NRIC parameter missing
-        assertParseFailure(parser, MEDCON_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DelMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, MEDCON_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DelMedConCommand.MESSAGE_USAGE));
 
         // MedCon parameter missing
-        assertParseFailure(parser, NRIC_DESC_AMY, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DelMedConCommand.MESSAGE_USAGE));
-        assertParseFailure(parser, NRIC_DESC_AMY + " " + PREFIX_MEDCON, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DelMedConCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, NRIC_DESC_AMY,
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, DelMedConCommand.MESSAGE_USAGE));
 
+        // MedCon prefix present, but no value
+        assertParseFailure(parser, NRIC_DESC_AMY + " " + PREFIX_MEDCON,
+                "Medical condition " + MESSAGE_EMPTY_FIELD);
     }
 
+
     @Test
-    public void parse_medConLengthGreaterThan45Characters_failure() {
-        // Medical condition exceeds 45 characters
-        String input = NRIC_DESC_AMY + " c/ThisMedicalConditionIsWayTooLongAndExceedsTheCharacterLimit";
-        assertParseFailure(parser, input, MESSAGE_CONSTRAINTS_LENGTH);
+    public void parse_medConLengthGreaterThan30Characters_failure() {
+        // Medical condition exceeds 30 characters
+        String input = NRIC_DESC_AMY + INVALID_MEDCON_DESC;
+        assertParseFailure(parser, input, "Medical condition " + MESSAGE_CONSTRAINTS_LENGTH);
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -21,6 +21,7 @@ import seedu.address.model.person.Address;
 import seedu.address.model.person.DateOfBirth;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Gender;
+import seedu.address.model.person.MedCon;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Phone;
@@ -31,6 +32,7 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_ALLERGY = "#friend";
+    private static final String INVALID_MEDCON = "@Diabetes";
     private static final String INVALID_NRIC = "S123456";
     private static final String INVALID_GENDER = "x";
     private static final String INVALID_DATE_OF_BIRTH_FORMAT = "2020/12/12";
@@ -42,6 +44,7 @@ public class ParserUtilTest {
     private static final String VALID_ADDRESS = "123 Main Street #0505";
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_ALLERGY_1 = "friend";
+    private static final String VALID_MEDCON = "Diabetes";
     private static final String VALID_NRIC = "T0123456A";
     private static final String VALID_GENDER = "f";
     private static final String VALID_DOB = "2020-11-11";
@@ -282,4 +285,26 @@ public class ParserUtilTest {
 
         assertEquals(expectedTagSet, actualTagSet);
     }
+
+    @Test
+    public void parseMedCon_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMedCon(null));
+    }
+
+    @Test
+    public void parseMedCon_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseMedCon(INVALID_MEDCON));
+    }
+
+    @Test
+    public void parseMedCon_validValueWithoutWhitespace_returnsMedCon() throws Exception {
+        MedCon expectedMedCon = new MedCon(VALID_MEDCON);
+        assertEquals(expectedMedCon, ParserUtil.parseMedCon(VALID_MEDCON));
+    }
+
+    @Test
+    public void parseMedCons_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseMedCon(null));
+    }
+
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedMedConTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMedConTest.java
@@ -1,21 +1,53 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.MedCon;
 
 public class JsonAdaptedMedConTest {
 
     private static final String VALID_MEDCON = "Diabetes";
-    private static final String INVALID_MEDCON = null;
+    private static final String INVALID_MEDCON_EMPTY = "";
+    private static final String INVALID_MEDCON_TOO_LONG =
+            "ThisMedicalConditionNameIsWayTooLongAndExceedsThirtyCharacters";
+    private static final String INVALID_MEDCON_SPECIAL_CHARS = "@Diabetes";
 
     @Test
     public void toModelType_validMedCon_returnsMedCon() throws Exception {
         JsonAdaptedMedCon jsonAdaptedMedCon = new JsonAdaptedMedCon(VALID_MEDCON);
         MedCon expectedMedCon = new MedCon(VALID_MEDCON);
         assertEquals(expectedMedCon, jsonAdaptedMedCon.toModelType());
+    }
+
+    @Test
+    public void toModelType_nullMedCon_throwsIllegalValueException() {
+        JsonAdaptedMedCon jsonAdaptedMedCon = new JsonAdaptedMedCon((String) null);
+        String expectedMessage = String.format("MedCon cannot be null",
+                MedCon.class.getSimpleName());
+        assertThrows(IllegalValueException.class, expectedMessage, () -> jsonAdaptedMedCon.toModelType());
+    }
+
+
+    @Test
+    public void toModelType_invalidMedConEmpty_throwsIllegalValueException() {
+        JsonAdaptedMedCon jsonAdaptedMedCon = new JsonAdaptedMedCon("");
+        String expectedMessage = "MedCon: length should not exceed the limit of 30 characters";
+
+        // Ensure that an IllegalValueException is thrown with the expected message
+        assertThrows(IllegalValueException.class, expectedMessage, () -> jsonAdaptedMedCon.toModelType());
+    }
+
+
+    @Test
+    public void toModelType_invalidMedConTooLong_throwsIllegalValueException() {
+        JsonAdaptedMedCon jsonAdaptedMedCon = new JsonAdaptedMedCon(INVALID_MEDCON_TOO_LONG);
+        assertThrows(IllegalValueException.class, "MedCon: " + MESSAGE_CONSTRAINTS_LENGTH, ()
+                -> jsonAdaptedMedCon.toModelType());
     }
 
     @Test


### PR DESCRIPTION
- Add validation for medical condition fields to ensure consistency:
  - Limit character length to 30 characters.
  - Introduce proper error messages for invalid fields.
- Add utility functions to `ArgumentMultimap` to reduce duplication:
  - Moved `arePrefixesPresent` to `ArgumentMultimap`.
  - Introduced `requireAllPrefixesPresent` in `ParserUtil` for prefix validation.
- Improve code reuse across multiple parser classes:
  - Extracted common validation logic to `ParserUtil`.
  - Updated `AddMedConCommandParser` and `DelMedConCommandParser` to use the new utility functions.
- Modify success messages to provide more clarity.
- Update test cases:
  - Added test cases for new validation rules and `DelMedConCommand`.
  - Updated test cases to ensure proper failure for missing or incorrect fields.

Fixes #149 