### PR TITLE
Update ui split pane

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -33,6 +34,7 @@ public interface Logic {
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
 
+    ObservableList<Appointment> getFilteredAppointmentList();
     /**
      * Returns the user prefs' address book file path.
      */

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -69,6 +70,11 @@ public class LogicManager implements Logic {
     @Override
     public ObservableList<Person> getFilteredPersonList() {
         return model.getFilteredPersonList();
+    }
+
+    @Override
+    public ObservableList<Appointment> getFilteredAppointmentList() {
+        return model.getFilteredAppointmentList();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -32,8 +32,6 @@ public class AddAllergyCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Added allergy: %1$s to Nric: %2$s";
     public static final String MESSAGE_DUPLICATE_ALLERGY = "This allergy already exists in the address book: %1$s";
-    public static final String MESSAGE_CONSTRAINT = "Allergy should be alphanumeric "
-            + "and not exceed 30 characters long. \n%1$s";
     private final Nric nric;
     private final Set<Allergy> allergies;
 

--- a/src/main/java/seedu/address/logic/commands/AddApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddApptCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMEPERIOD;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
@@ -93,6 +94,7 @@ public class AddApptCommand extends Command {
         logger.info("AddAppt command has been exceuted successfully on a person with NRIC: "
                 + editedPerson.getNric());
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
         return new CommandResult(String.format(MESSAGE_SUCCESS_4S, editedPerson.getNric(), newApptName, newApptDate,
                                                newApptTime));
     }

--- a/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteApptCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TIMEPERIOD;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_APPOINTMENTS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.ArrayList;
@@ -85,6 +86,7 @@ public class DeleteApptCommand extends Command {
         logger.info("delAppt command has been exceuted successfully on a person with NRIC: " + targetNric + " for "
                     + "appointment: " + targetAppt);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredAppointmentList(PREDICATE_SHOW_ALL_APPOINTMENTS);
         return new CommandResult(String.format(MESSAGE_DELETE_APPOINTMENT_SUCCESS_2S,
                                                apptToDelete,
                                                personToEdit.getNric().value));

--- a/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddAllergyCommandParser.java
@@ -36,19 +36,14 @@ public class AddAllergyCommandParser implements Parser<AddAllergyCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC);
 
-        try {
-            Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
-            Set<Allergy> allergies = ParserUtil.parseAllergies(argMultimap.getAllValues(PREFIX_ALLERGY));
+        Nric nric = ParserUtil.parseNric(argMultimap.getValue(PREFIX_NRIC).get());
+        Set<Allergy> allergies = ParserUtil.parseAllergies(argMultimap.getAllValues(PREFIX_ALLERGY));
 
-            logger.info("Successfully parsed nric for AddAllergyCommand: " + nric);
-            logger.info("Successfully parsed allergies for AddAllergyCommand: " + allergies);
+        logger.info("Successfully parsed nric for AddAllergyCommand: " + nric);
+        logger.info("Successfully parsed allergies for AddAllergyCommand: " + allergies);
 
-            return new AddAllergyCommand(nric, allergies);
-        } catch (ParseException pe) {
-            logger.warning("Unable to parse the nric or allergies for FindNricCommand: " + args);
-            throw new ParseException(
-                    String.format(AddAllergyCommand.MESSAGE_CONSTRAINT, AddAllergyCommand.MESSAGE_USAGE), pe);
-        }
+        return new AddAllergyCommand(nric, allergies);
+
     }
 
     /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -15,7 +15,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_DATE = new Prefix("@d/");
     public static final Prefix PREFIX_TIMEPERIOD = new Prefix("@t/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
-    public static final Prefix PREFIX_ALLERGY = new Prefix("t/");
+    public static final Prefix PREFIX_ALLERGY = new Prefix("al/");
     public static final Prefix PREFIX_PRIORITY = new Prefix("!/");
     public static final Prefix PREFIX_MEDCON = new Prefix("c/");
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -4,8 +4,10 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.List;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -16,7 +18,7 @@ import seedu.address.model.person.UniquePersonList;
 public class AddressBook implements ReadOnlyAddressBook {
 
     private final UniquePersonList persons;
-
+    private final ObservableList<Appointment> appointments = FXCollections.observableArrayList();
     /*
      * The 'unusual' code block below is a non-static initialization block, sometimes used to avoid duplication
      * between constructors. See https://docs.oracle.com/javase/tutorial/java/javaOO/initial.html
@@ -53,8 +55,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void resetData(ReadOnlyAddressBook newData) {
         requireNonNull(newData);
-
         setPersons(newData.getPersonList());
+        updateAppointmentList();
     }
 
     //// person-level operations
@@ -82,8 +84,8 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void setPerson(Person target, Person editedPerson) {
         requireNonNull(editedPerson);
-
         persons.setPerson(target, editedPerson);
+        updateAppointmentList();
     }
 
     /**
@@ -92,8 +94,19 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePerson(Person key) {
         persons.remove(key);
+        updateAppointmentList();
     }
 
+    //// appointment-level operations
+    /**
+     * Updates and refreshes the appointment list in the {@code AddressBook}.
+     */
+    public void updateAppointmentList() {
+        appointments.clear();
+        for (Person person : persons) {
+            appointments.addAll(person.getAppointments());
+        }
+    }
     //// util methods
 
     @Override
@@ -106,6 +119,11 @@ public class AddressBook implements ReadOnlyAddressBook {
     @Override
     public ObservableList<Person> getPersonList() {
         return persons.asUnmodifiableObservableList();
+    }
+
+    @Override
+    public ObservableList<Appointment> getAppointmentList() {
+        return appointments;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -6,6 +6,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 
@@ -15,6 +16,7 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+    Predicate<Appointment> PREDICATE_SHOW_ALL_APPOINTMENTS = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -82,9 +84,12 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    ObservableList<Appointment> getFilteredAppointmentList();
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    void updateFilteredAppointmentList(Predicate<Appointment> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -13,6 +13,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 
@@ -25,6 +26,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+    private final FilteredList<Appointment> filteredAppts;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -37,6 +39,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredAppts = new FilteredList<>(this.addressBook.getAppointmentList());
     }
 
     public ModelManager() {
@@ -126,9 +129,19 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public ObservableList<Appointment> getFilteredAppointmentList() {
+        return filteredAppts;
+    }
+    @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+
+    @Override
+    public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
+        requireNonNull(predicate);
+        filteredAppts.setPredicate(predicate);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
+++ b/src/main/java/seedu/address/model/ReadOnlyAddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,5 +14,9 @@ public interface ReadOnlyAddressBook {
      * This list will not contain any duplicate persons.
      */
     ObservableList<Person> getPersonList();
-
+    /**
+     * Returns an unmodifiable view of the appointments list.
+     * This list will not contain any duplicate appointments.
+     */
+    ObservableList<Appointment> getAppointmentList();
 }

--- a/src/main/java/seedu/address/ui/AppointmentCard.java
+++ b/src/main/java/seedu/address/ui/AppointmentCard.java
@@ -1,0 +1,45 @@
+package seedu.address.ui;
+
+import javafx.fxml.FXML;
+import javafx.scene.control.Label;
+import javafx.scene.layout.HBox;
+import javafx.scene.layout.Region;
+import seedu.address.model.appointment.Appointment;
+
+/**
+ * UI component that displays information of a {@code Appointment}.
+ */
+public class AppointmentCard extends UiPart<Region> {
+
+    private static final String FXML = "AppointmentListCard.fxml";
+
+    /**
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
+     * As a consequence, UI elements' variable names cannot be set to such keywords
+     * or an exception will be thrown by JavaFX during runtime.
+     *
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     */
+
+    public final Appointment appt;
+
+    @FXML
+    private HBox cardPane;
+    @FXML
+    private Label date;
+    @FXML
+    private Label timePeriod;
+    @FXML
+    private Label appointmentName;
+
+    /**
+     * Creates a {@code AppointmentCard} with the given {@code Appointment} and index to display.
+     */
+    public AppointmentCard(Appointment appt) {
+        super(FXML);
+        this.appt = appt;
+        date.setText(appt.getAppointmentDate());
+        timePeriod.setText(appt.getAppointmentTimePeriod());
+        appointmentName.setText(appt.getAppointmentName());
+    }
+}

--- a/src/main/java/seedu/address/ui/AppointmentListPanel.java
+++ b/src/main/java/seedu/address/ui/AppointmentListPanel.java
@@ -1,0 +1,44 @@
+package seedu.address.ui;
+
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.control.ListCell;
+import javafx.scene.control.ListView;
+import javafx.scene.layout.Region;
+import seedu.address.model.appointment.Appointment;
+
+/**
+ * Panel containing the list of appointment
+ */
+public class AppointmentListPanel extends UiPart<Region> {
+    private static final String FXML = "AppointmentListPanel.fxml";
+
+    @FXML
+    private ListView<Appointment> appointmentListView;
+
+    /**
+     * Creates a {@code NoteListPanel} with the given {@code ObservableList}.
+     */
+    public AppointmentListPanel(ObservableList<Appointment> appointmentList) {
+        super(FXML);
+        appointmentListView.setItems(appointmentList);
+        appointmentListView.setCellFactory(listView -> new AppointmentListViewCell());
+    }
+
+    /**
+     * Custom {@code ListCell} that displays the graphics of a {@code Appointment} using a {@code AppointmentCard}.
+     */
+    class AppointmentListViewCell extends ListCell<Appointment> {
+        @Override
+        protected void updateItem(Appointment appointment, boolean empty) {
+            super.updateItem(appointment, empty);
+
+            if (empty || appointment == null) {
+                setGraphic(null);
+                setText(null);
+            } else {
+                setGraphic(new AppointmentCard(appointment).getRoot());
+            }
+        }
+    }
+}

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2425s1-cs2103t-f12-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -32,6 +32,7 @@ public class MainWindow extends UiPart<Stage> {
 
     // Independent Ui parts residing in this Ui container
     private PersonListPanel personListPanel;
+    private AppointmentListPanel appointmentListPanel;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -43,6 +44,9 @@ public class MainWindow extends UiPart<Stage> {
 
     @FXML
     private StackPane personListPanelPlaceholder;
+
+    @FXML
+    private StackPane appointmentListPanelPlaceholder;
 
     @FXML
     private StackPane resultDisplayPlaceholder;
@@ -111,7 +115,10 @@ public class MainWindow extends UiPart<Stage> {
      */
     void fillInnerParts() {
         personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        appointmentListPanel = new AppointmentListPanel(logic.getFilteredAppointmentList());
+
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
+        appointmentListPanelPlaceholder.getChildren().add(appointmentListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -167,6 +174,9 @@ public class MainWindow extends UiPart<Stage> {
         return personListPanel;
     }
 
+    public AppointmentListPanel getAppointmentListPanel() {
+        return appointmentListPanel;
+    }
     /**
      * Executes the command and returns the result.
      *

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -1,13 +1,10 @@
 package seedu.address.ui;
 
-import java.util.logging.Logger;
-
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
-import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
 
 /**
@@ -15,7 +12,6 @@ import seedu.address.model.person.Person;
  */
 public class PersonListPanel extends UiPart<Region> {
     private static final String FXML = "PersonListPanel.fxml";
-    private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
     @FXML
     private ListView<Person> personListView;

--- a/src/main/java/seedu/address/ui/UiPart.java
+++ b/src/main/java/seedu/address/ui/UiPart.java
@@ -84,5 +84,4 @@ public abstract class UiPart<T> {
         URL fxmlFileUrl = MainApp.class.getResource(fxmlFileNameWithFolder);
         return requireNonNull(fxmlFileUrl);
     }
-
 }

--- a/src/main/resources/view/AppointmentListPanel.fxml
+++ b/src/main/resources/view/AppointmentListPanel.fxml
@@ -7,6 +7,6 @@
 
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
     <Text text="Appointments" styleClass="label-bright" style="-fx-fill: white" />
-    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+    <ListView fx:id="appointmentListView" VBox.vgrow="ALWAYS" />
 </VBox>
 

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -34,18 +34,18 @@
         </MenuBar>
 
         <SplitPane VBox.vgrow="ALWAYS">
-          <VBox fx:id="personList" styleClass="pane-with-border" minWidth="340" prefWidth="340" VBox.vgrow="ALWAYS">
+          <VBox fx:id="personList" styleClass="pane-with-border" minWidth="500" prefWidth="500" VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>
             <StackPane fx:id="personListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
-          <VBox fx:id="appointmentList" styleClass="pane-with-border" minWidth="340" prefWidth="340"
+          <VBox fx:id="appointmentList" styleClass="pane-with-border" minWidth="200" prefWidth="200"
                 VBox.vgrow="ALWAYS">
             <padding>
               <Insets top="10" right="10" bottom="10" left="10"/>
             </padding>
-            <StackPane fx:id="appointmentListPanel" VBox.vgrow="ALWAYS"/>
+            <StackPane fx:id="appointmentListPanelPlaceholder" VBox.vgrow="ALWAYS"/>
           </VBox>
         </SplitPane>
 

--- a/src/main/resources/view/PersonListPanel.fxml
+++ b/src/main/resources/view/PersonListPanel.fxml
@@ -3,7 +3,8 @@
 <?import javafx.scene.control.ListView?>
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
+
 <VBox xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
   <Text text="Patients" styleClass="label-bright" style="-fx-fill: white" />
-  <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
+    <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
 </VBox>

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -23,6 +23,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
@@ -156,12 +157,21 @@ public class AddCommandTest {
         }
 
         @Override
+        public ObservableList<Appointment> getFilteredAppointmentList() {
+            throw new AssertionError("This method should not be called.");
+        }
+        @Override
         public ObservableList<Person> getFilteredPersonList() {
             throw new AssertionError("This method should not be called.");
         }
 
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredAppointmentList(Predicate<Appointment> predicate) {
             throw new AssertionError("This method should not be called.");
         }
     }

--- a/src/test/java/seedu/address/model/AddressBookTest.java
+++ b/src/test/java/seedu/address/model/AddressBookTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.appointment.Appointment;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.testutil.PersonBuilder;
@@ -96,7 +97,7 @@ public class AddressBookTest {
      */
     private static class AddressBookStub implements ReadOnlyAddressBook {
         private final ObservableList<Person> persons = FXCollections.observableArrayList();
-
+        private final ObservableList<Appointment> appointments = FXCollections.observableArrayList();
         AddressBookStub(Collection<Person> persons) {
             this.persons.setAll(persons);
         }
@@ -104,6 +105,11 @@ public class AddressBookTest {
         @Override
         public ObservableList<Person> getPersonList() {
             return persons;
+        }
+
+        @Override
+        public ObservableList<Appointment> getAppointmentList() {
+            return appointments;
         }
     }
 


### PR DESCRIPTION
Fixes #155 

Currently, Appointment in a split pane shows the details but is not in a sorted order.
We could consider displaying a sorted appointment list from earliest to latest

As of now, this is how the UI is shown
![image](https://github.com/user-attachments/assets/29a27c1a-2292-4ecf-b654-3488a9212452)


However, all fields need to be constraint to a reasonable length as this would prevent the tags from wrapping. 
It follows the longest tag before wrapping, thus a bug can be induce by keying in a long text, and reducing the 
UI screen size, which will make some of the tags overflow as shown in the image.

![image](https://github.com/user-attachments/assets/e145c59b-6def-4be0-8c91-c65de2eb0cd4)
