### PR TITLE
Change error message for Delete and FindNRIC command

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,4 +70,8 @@ shadowJar {
     archiveFileName = 'medibase3.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -24,7 +24,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
         if (args.isEmpty()) {
-            logger.warning("Unable to parse the NRIC for DeleteCommand: " + args);
+            logger.warning("Received empty NRIC for DeleteCommand");
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
         }
@@ -34,8 +34,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             return new DeleteCommand(new NricMatchesPredicate(patientNric));
         } catch (ParseException pe) {
             logger.warning("Unable to parse the NRIC for DeleteCommand: " + args);
-            throw new ParseException(
-                    String.format(pe.getMessage(), DeleteCommand.MESSAGE_USAGE));
+            throw new ParseException(pe.getMessage());
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -23,6 +23,11 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            logger.warning("Unable to parse the NRIC for DeleteCommand: " + args);
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        }
         try {
             Nric patientNric = ParserUtil.parseNric(args);
             logger.info("Successfully parsed the NRIC for DeleteCommand: " + patientNric);
@@ -30,7 +35,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         } catch (ParseException pe) {
             logger.warning("Unable to parse the NRIC for DeleteCommand: " + args);
             throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                    String.format(pe.getMessage(), DeleteCommand.MESSAGE_USAGE));
         }
     }
 

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -23,7 +23,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format.
      */
     public DeleteCommand parse(String args) throws ParseException {
-        if (args.isEmpty()) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
             logger.warning("Received empty NRIC for DeleteCommand");
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));

--- a/src/main/java/seedu/address/logic/parser/FindNricCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindNricCommandParser.java
@@ -22,14 +22,18 @@ public class FindNricCommandParser implements Parser<FindNricCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindNricCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            logger.warning("Received empty NRIC for FindNricCommand");
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindNricCommand.MESSAGE_USAGE));
+        }
         try {
             Nric patientNric = ParserUtil.parseNric(args);
             logger.info("Successfully parsed the NRIC for FindNricCommand: " + patientNric);
             return new FindNricCommand(new NricMatchesPredicate(patientNric));
         } catch (ParseException pe) {
             logger.warning("Unable to parse the NRIC for FindNricCommand: " + args);
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindNricCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(pe.getMessage());
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/FindNricCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindNricCommandParser.java
@@ -22,7 +22,8 @@ public class FindNricCommandParser implements Parser<FindNricCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public FindNricCommand parse(String args) throws ParseException {
-        if (args.isEmpty()) {
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
             logger.warning("Received empty NRIC for FindNricCommand");
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindNricCommand.MESSAGE_USAGE));

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -36,7 +36,6 @@ public class DeleteCommandParserTest {
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT,
                 DeleteCommand.MESSAGE_USAGE));
         //invalid NRIC
-        assertParseFailure(parser, INVALID_NRIC, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, INVALID_NRIC, Nric.MESSAGE_CONSTRAINTS);
     }
 }


### PR DESCRIPTION
fixes #158 
* Changed the error message to be displayed when receiving empty arguments
* Changed the error message to be displayed when invalid NRIC

Enabled assertions when using `./gradlew run` as per tP requirements for v1.4