### PR TITLE
Fix CSS bug for Allergy tag

### DIFF
--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -344,12 +344,12 @@
     -fx-background-radius: 0;
 }
 
-#tags {
+#allergies {
     -fx-hgap: 7;
     -fx-vgap: 3;
 }
 
-#tags .label {
+#allergies .label {
     -fx-text-fill: white;
     -fx-background-color: #3e7b91;
     -fx-padding: 1 3 1 3;


### PR DESCRIPTION
fixes #170 

CSS class for `tag` should be renamed to `allergies`