### PR TITLE
Update undo sequence diagram model in developer guide

### DIFF
--- a/docs/diagrams/UndoSequenceDiagram-Model.puml
+++ b/docs/diagrams/UndoSequenceDiagram-Model.puml
@@ -14,6 +14,9 @@ Model -> VersionedAddressBook : undo()
 activate VersionedAddressBook
 
 VersionedAddressBook -> VersionedAddressBook :resetData(ReadOnlyAddressBook)
+activate VersionedAddressBook
+VersionedAddressBook --> VersionedAddressBook
+deactivate VersionedAddressBook
 VersionedAddressBook --> Model :
 deactivate VersionedAddressBook
 


### PR DESCRIPTION
fixes #183 
What changed:
- Update the sequence diagram in the developer guide to show the self-invocation activation bar and return arrow.
- This change is unnecessary as the tp requirement was to omit less important details.
- However, as the tp week 10 requirement requires us to edit at least 3 lines of puml, this change was done.
- This change is to be reverted once we have confirmed with the TA what is expected/needed when drawing the implementation diagram.
![image](https://github.com/user-attachments/assets/93eed59f-27b4-4431-a353-ca94cfdf1eb0)
