### PR TITLE
Bug: Able to add duplicate allergies

### DIFF
--- a/src/main/java/seedu/address/model/person/Allergy.java
+++ b/src/main/java/seedu/address/model/person/Allergy.java
@@ -26,7 +26,7 @@ public class Allergy implements Comparable<Allergy> {
         requireNonNull(allergyName);
         checkArgument(!allergyName.isEmpty(), MESSAGE_EMPTY_FIELD);
         checkArgument(isValidAllergyName(allergyName), MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH);
-        this.allergyName = allergyName;
+        this.allergyName = allergyName.toUpperCase();
     }
 
     /**


### PR DESCRIPTION
fixes #213 

Currently, there is a bug where a user can key in 2 allergies with the same name but different casing.

What changed:
- Allergy will all be save as uppercase for consistency.
- As allergy is an important information, it is more appropriate for it to be capitalised so that the doctor would not administer any medication containing such allergies. 
- Comparison between allergies will only be in uppercase which will resolve the bug of adding 2 allergies of the same name but of different case.