### PR TITLE
Add more specific error message for invalid DateOfBirth

### DIFF
--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -14,8 +14,9 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class DateUtil {
 
-    private static final String DATE_FORMAT = "uuuu-MM-dd";
-    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_FORMAT)
+    private static final String DATE_VALIDATION_FORMAT = "uuuu-MM-dd";
+    private static final String DATE_FORMAT_PATTERN = "\\d{4}-\\d{2}-\\d{2}";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_VALIDATION_FORMAT)
             .withResolverStyle(ResolverStyle.STRICT);
     private static final Logger logger = LogsCenter.getLogger(DateUtil.class);
 
@@ -36,12 +37,20 @@ public class DateUtil {
                 .orElse(false);
     }
 
+    /**
+     * Returns if a given string is in the correct date format.
+     */
+    public static boolean isCorrectDateFormat(String date) {
+        return date.matches(DATE_FORMAT_PATTERN);
+    }
+
     private static Optional<LocalDate> parseDate(String date) {
         try {
             LocalDate parsedDate = LocalDate.parse(date, DATE_FORMATTER);
             logger.fine("Parsed date: " + parsedDate);
             return Optional.of(parsedDate);
         } catch (DateTimeException e) {
+            System.out.println(e.getMessage());
             logger.warning("Unable to parse date: " + date);
             return Optional.empty();
         }

--- a/src/main/java/seedu/address/commons/util/DateUtil.java
+++ b/src/main/java/seedu/address/commons/util/DateUtil.java
@@ -14,8 +14,11 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class DateUtil {
 
+    public static final String MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST = "The given date is invalid and does not exist "
+            + "in the calendar.";
     private static final String DATE_VALIDATION_FORMAT = "uuuu-MM-dd";
     private static final String DATE_FORMAT_PATTERN = "\\d{4}-\\d{2}-\\d{2}";
+
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern(DATE_VALIDATION_FORMAT)
             .withResolverStyle(ResolverStyle.STRICT);
     private static final Logger logger = LogsCenter.getLogger(DateUtil.class);

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -122,12 +122,19 @@ public class ParserUtil {
     public static DateOfBirth parseDateOfBirth(String dob) throws ParseException {
         requireNonNull(dob);
         String trimmedDob = dob.trim();
-        if (!DateUtil.isValidDate(trimmedDob)) {
+
+        if (!DateUtil.isCorrectDateFormat(trimmedDob)) {
             throw new ParseException(DateOfBirth.MESSAGE_CONSTRAINTS_WRONG_FORMAT);
         }
+
+        if (!DateUtil.isValidDate(trimmedDob)) {
+            throw new ParseException(DateOfBirth.MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST);
+        }
+
         if (!DateOfBirth.isValidDateOfBirth(trimmedDob)) {
             throw new ParseException(DateOfBirth.MESSAGE_CONSTRAINTS_FUTURE_DATE);
         }
+
         return new DateOfBirth(trimmedDob);
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -128,7 +128,7 @@ public class ParserUtil {
         }
 
         if (!DateUtil.isValidDate(trimmedDob)) {
-            throw new ParseException(DateOfBirth.MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST);
+            throw new ParseException(DateUtil.MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST);
         }
 
         if (!DateOfBirth.isValidDateOfBirth(trimmedDob)) {

--- a/src/main/java/seedu/address/model/person/DateOfBirth.java
+++ b/src/main/java/seedu/address/model/person/DateOfBirth.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.DateUtil.MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST;
 import static seedu.address.commons.util.DateUtil.isCorrectDateFormat;
 import static seedu.address.commons.util.DateUtil.isDateAfterToday;
 import static seedu.address.commons.util.DateUtil.isValidDate;
@@ -14,8 +15,7 @@ public class DateOfBirth {
     public static final String MESSAGE_CONSTRAINTS_FUTURE_DATE = "Date of birth should not be after today's date.";
     public static final String MESSAGE_CONSTRAINTS_WRONG_FORMAT = "Date of birth should be in the format of yyyy-MM-dd"
             + " and should not be blank.";
-    public static final String MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST = "The given date is invalid and does not exist "
-            + "in the calendar.";
+
 
     public final String value;
 
@@ -26,7 +26,6 @@ public class DateOfBirth {
      */
     public DateOfBirth(String dob) {
         requireNonNull(dob);
-        assert dob.length() == 10 : "Date of birth should be 10 characters long";
         checkArgument(isCorrectDateFormat(dob), MESSAGE_CONSTRAINTS_WRONG_FORMAT);
         checkArgument(isValidDate(dob), MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST);
         checkArgument(isValidDateOfBirth(dob), MESSAGE_CONSTRAINTS_FUTURE_DATE);

--- a/src/main/java/seedu/address/model/person/DateOfBirth.java
+++ b/src/main/java/seedu/address/model/person/DateOfBirth.java
@@ -2,6 +2,7 @@ package seedu.address.model.person;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+import static seedu.address.commons.util.DateUtil.isCorrectDateFormat;
 import static seedu.address.commons.util.DateUtil.isDateAfterToday;
 import static seedu.address.commons.util.DateUtil.isValidDate;
 
@@ -10,10 +11,12 @@ import static seedu.address.commons.util.DateUtil.isValidDate;
  * Guarantees: immutable; is valid as declared in {@link #isValidDateOfBirth(String)}
  */
 public class DateOfBirth {
-    public static final String MESSAGE_CONSTRAINTS_FUTURE_DATE = "Date of birth should be a valid date and "
-            + "not after today's date";
-    public static final String MESSAGE_CONSTRAINTS_WRONG_FORMAT = "Date of birth should be a valid date "
-            + "in the format of yyyy-MM-dd";
+    public static final String MESSAGE_CONSTRAINTS_FUTURE_DATE = "Date of birth should not be after today's date.";
+    public static final String MESSAGE_CONSTRAINTS_WRONG_FORMAT = "Date of birth should be in the format of yyyy-MM-dd"
+            + " and should not be blank.";
+    public static final String MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST = "The given date is invalid and does not exist "
+            + "in the calendar.";
+
     public final String value;
 
     /**
@@ -23,7 +26,9 @@ public class DateOfBirth {
      */
     public DateOfBirth(String dob) {
         requireNonNull(dob);
-        checkArgument(isValidDate(dob), MESSAGE_CONSTRAINTS_WRONG_FORMAT);
+        assert dob.length() == 10 : "Date of birth should be 10 characters long";
+        checkArgument(isCorrectDateFormat(dob), MESSAGE_CONSTRAINTS_WRONG_FORMAT);
+        checkArgument(isValidDate(dob), MESSAGE_CONSTRAINTS_DATE_DOES_NOT_EXIST);
         checkArgument(isValidDateOfBirth(dob), MESSAGE_CONSTRAINTS_FUTURE_DATE);
         this.value = dob;
     }
@@ -34,7 +39,6 @@ public class DateOfBirth {
     public static boolean isValidDateOfBirth(String dob) {
         return !(isDateAfterToday(dob));
     }
-
     @Override
     public String toString() {
         return this.value;

--- a/src/main/java/seedu/address/model/person/Gender.java
+++ b/src/main/java/seedu/address/model/person/Gender.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Gender {
 
-    public static final String MESSAGE_CONSTRAINTS = "Gender should be either 'M' or 'F'";
+    public static final String MESSAGE_CONSTRAINTS = "Gender should be either 'M' or 'F' and it should not be blank.";
     public static final String VALIDATION_REGEX = "[mMfF]";
 
     public final String value;

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -22,7 +22,6 @@ public class Nric {
      */
     public Nric(String nric) {
         requireNonNull(nric);
-        assert nric.length() == 9 : "NRIC should be 9 characters long";
         checkArgument(isValidNric(nric), MESSAGE_CONSTRAINTS);
         this.value = nric.toUpperCase();
     }

--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Nric {
     public static final String MESSAGE_CONSTRAINTS = "NRIC should start with S, T, F or G, "
-            + "followed by 7 digits, and end with a letter.";
+            + "followed by 7 digits, and end with a letter. It should not be blank.";
     //Regex accounts for both uppercase and lowercase NRIC and FIN formats
     public static final String VALIDATION_REGEX = "(?i)^[STFG]\\d{7}[A-Z]$";
 
@@ -22,6 +22,7 @@ public class Nric {
      */
     public Nric(String nric) {
         requireNonNull(nric);
+        assert nric.length() == 9 : "NRIC should be 9 characters long";
         checkArgument(isValidNric(nric), MESSAGE_CONSTRAINTS);
         this.value = nric.toUpperCase();
     }

--- a/src/test/java/seedu/address/commons/util/DateUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/DateUtilTest.java
@@ -2,6 +2,7 @@ package seedu.address.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.util.DateUtil.isCorrectDateFormat;
 import static seedu.address.commons.util.DateUtil.isDateAfterToday;
 import static seedu.address.commons.util.DateUtil.isValidDate;
 
@@ -22,8 +23,14 @@ public class DateUtilTest {
         assertFalse(isValidDate(" ")); // spaces only
         assertFalse(isValidDate("example")); // non-numeric
         assertFalse(isValidDate("2022-13-01")); // invalid month
-        assertFalse(isValidDate("2022-12-32")); // invalid day
+        assertFalse(isValidDate("2023-02-29")); // invalid day
         assertFalse(isValidDate("2022/12/12")); // invalid format
+    }
+
+    @Test
+    public void isCorrectDateFormat_correctFormat_returnsTrue() {
+        assertTrue(isCorrectDateFormat("2022-12-12"));
+        assertTrue(isCorrectDateFormat("2023-02-29")); // returns true even if date does not exist
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/address/logic/parser/ParserUtilTest.java
@@ -31,7 +31,8 @@ public class ParserUtilTest {
     private static final String INVALID_NRIC = "S123456";
     private static final String INVALID_GENDER = "x";
     private static final String INVALID_DATE_OF_BIRTH_FORMAT = "2020/12/12";
-    private static final String INVALID_DATE_OF_BIRTH_VALUE = LocalDate.now().plusDays(2)
+    private static final String INVALID_DATE_OF_BIRTH_VALUE = "2023-02-29";
+    private static final String INVALID_DATE_OF_BIRTH_FUTURE = LocalDate.now().plusDays(2)
             .format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
 
     private static final String VALID_NAME = "Rachel Walker";
@@ -190,6 +191,11 @@ public class ParserUtilTest {
     @Test
     public void parseDateOfBirth_invalidFormat_throwsParseException() {
         assertThrows(ParseException.class, () -> ParserUtil.parseDateOfBirth(INVALID_DATE_OF_BIRTH_FORMAT));
+    }
+
+    @Test
+    public void parseDateOfBirth_invalidFutureDate_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseDateOfBirth(INVALID_DATE_OF_BIRTH_FUTURE));
     }
 
     @Test


### PR DESCRIPTION
fixes #229 

Changes made:
* Added a new method in `DateUtil` called `isCorrectDateFormat` which checks if the given string is in the correct date format `yyyy-MM-dd` . It does not check if the given date is
* When parsing `DateOfBirth`:
Check if given string follows the correct date format-> Check if given date is a valid date that exists -> Check if given date is in the future
* If date does not exist, the error message will display `The given date is invalid and does not exist in the calander.`

@yadobler you can consider using this method for #227 