### PR TITLE
Rename PriorityCommandClass to SetPriorityCommand for consistency

### DIFF
--- a/src/main/java/seedu/address/logic/commands/SetPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SetPriorityCommand.java
@@ -15,7 +15,7 @@ import seedu.address.model.person.Priority;
 /**
  * Command to assign or update the priority of a patient in the address book.
  */
-public class PriorityCommand extends Command {
+public class SetPriorityCommand extends Command {
 
     public static final String COMMAND_WORD = "setPriority";
 
@@ -35,12 +35,12 @@ public class PriorityCommand extends Command {
     private final Nric nric;
 
     /**
-     * Creates a PriorityCommand to assign or update a person's priority.
+     * Creates a SetPriorityCommand to assign or update a person's priority.
      *
      * @param nric    The NRIC of the person whose priority is to be updated.
      * @param priority The priority to be assigned to the person.
      */
-    public PriorityCommand(Nric nric, Priority priority) {
+    public SetPriorityCommand(Nric nric, Priority priority) {
         requireAllNonNull(nric, priority);
 
         this.priority = priority;
@@ -90,7 +90,7 @@ public class PriorityCommand extends Command {
     }
 
     /**
-     * Checks if two PriorityCommand objects are equal.
+     * Checks if two SetPriorityCommand objects are equal.
      *
      * @param other The object to compare with.
      * @return True if both objects are the same or have the same NRIC and priority; false otherwise.
@@ -101,11 +101,11 @@ public class PriorityCommand extends Command {
             return true;
         }
 
-        if (!(other instanceof PriorityCommand)) {
+        if (!(other instanceof SetPriorityCommand)) {
             return false;
         }
 
-        PriorityCommand p = (PriorityCommand) other;
+        SetPriorityCommand p = (SetPriorityCommand) other;
         return nric.equals(p.nric)
                 && priority.equals(p.priority);
     }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -26,7 +26,7 @@ import seedu.address.logic.commands.FindNricCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.ListPrioCommand;
-import seedu.address.logic.commands.PriorityCommand;
+import seedu.address.logic.commands.SetPriorityCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -90,8 +90,8 @@ public class AddressBookParser {
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
 
-        case PriorityCommand.COMMAND_WORD:
-            return new PriorityCommandParser().parse(arguments);
+        case SetPriorityCommand.COMMAND_WORD:
+            return new SetPriorityCommandParser().parse(arguments);
 
         case AddApptCommand.COMMAND_WORD:
             return new AddApptCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/logic/parser/SetPriorityCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/SetPriorityCommandParser.java
@@ -5,38 +5,37 @@ import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 
-import seedu.address.logic.commands.PriorityCommand;
+import seedu.address.logic.commands.SetPriorityCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Priority;
 
 
 /**
- * Parses user input for the {@link PriorityCommand} and creates a new instance of it.
+ * Parses user input for the {@link SetPriorityCommand} and creates a new instance of it.
  */
-public class PriorityCommandParser implements Parser<PriorityCommand> {
+public class SetPriorityCommandParser implements Parser<SetPriorityCommand> {
 
     /**
-     * Parses the given arguments string and creates a {@link PriorityCommand} object.
+     * Parses the given arguments string and creates a {@link SetPriorityCommand} object.
      *
      * @param args the arguments string containing user input.
-     * @return A {@link PriorityCommand} object containing the parsed NRIC and priority.
+     * @return A {@link SetPriorityCommand} object containing the parsed NRIC and priority.
      * @throws ParseException if the user input does not conform to the expected format or
      *         if the NRIC or priority is not provided.
      */
-    public PriorityCommand parse(String args) throws ParseException {
+    public SetPriorityCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        String trimmedArgs = args.trim();
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args,
                 PREFIX_NRIC, PREFIX_PRIORITY);
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NRIC, PREFIX_PRIORITY);
         if (!argMultimap.getValue(PREFIX_NRIC).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    PriorityCommand.MESSAGE_USAGE));
+                    SetPriorityCommand.MESSAGE_USAGE));
         }
         if (!argMultimap.getValue(PREFIX_PRIORITY).isPresent()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    PriorityCommand.MESSAGE_USAGE));
+                    SetPriorityCommand.MESSAGE_USAGE));
         }
 
         String nricStr = argMultimap.getValue(PREFIX_NRIC).orElse("");
@@ -44,6 +43,6 @@ public class PriorityCommandParser implements Parser<PriorityCommand> {
         String priorityStr = argMultimap.getValue(PREFIX_PRIORITY).orElse("");
         Priority priority = ParserUtil.parsePriority(priorityStr);
 
-        return new PriorityCommand(nric, priority);
+        return new SetPriorityCommand(nric, priority);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/SetPriorityCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SetPriorityCommandTest.java
@@ -22,7 +22,7 @@ import seedu.address.model.person.NricMatchesPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Priority;
 
-public class PriorityCommandTest {
+public class SetPriorityCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     @Test
@@ -32,14 +32,14 @@ public class PriorityCommandTest {
         Priority firstPriority = new Priority(VALID_PRIORITY_AMY);
         Priority secondPriority = new Priority(VALID_PRIORITY_BOB);
 
-        PriorityCommand firstPriorityCommand = new PriorityCommand(firstNric, firstPriority);
-        PriorityCommand secondPriorityCommand = new PriorityCommand(secondNric, secondPriority);
+        SetPriorityCommand firstPriorityCommand = new SetPriorityCommand(firstNric, firstPriority);
+        SetPriorityCommand secondPriorityCommand = new SetPriorityCommand(secondNric, secondPriority);
 
         // same object -> returns true
         assertTrue(firstPriorityCommand.equals(firstPriorityCommand));
 
         // same value -> returns true
-        PriorityCommand firstPriorityCommandCopy = new PriorityCommand(firstNric, firstPriority);
+        SetPriorityCommand firstPriorityCommandCopy = new SetPriorityCommand(firstNric, firstPriority);
         assertTrue(firstPriorityCommand.equals(firstPriorityCommandCopy));
 
         // different types -> returns false
@@ -57,7 +57,7 @@ public class PriorityCommandTest {
         // ensures CommandException is thrown when provided with Nric that is not in addressbook
         Nric nric = new Nric("T1111111F");
         Priority priority = new Priority("HIGH");
-        PriorityCommand command = new PriorityCommand(nric, priority);
+        SetPriorityCommand command = new SetPriorityCommand(nric, priority);
         assertThrows(CommandException.class, () -> command.execute(model));
     }
 
@@ -71,7 +71,7 @@ public class PriorityCommandTest {
         Priority highPriority = new Priority("HIGH");
 
         // change priority from default "NONE" to "LOW"
-        CommandResult firstCommandResult = new PriorityCommand(aliceNric, lowPriority).execute(model);
+        CommandResult firstCommandResult = new SetPriorityCommand(aliceNric, lowPriority).execute(model);
         Person lowPriorityAlice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
                 .orElse(null);
 
@@ -79,7 +79,7 @@ public class PriorityCommandTest {
         assertEquals(lowPriority, lowPriorityAlice.getPriority());
 
         // change priority from "LOW to MEDIUM"
-        CommandResult secondCommandResult = new PriorityCommand(aliceNric, mediumPriority).execute(model);
+        CommandResult secondCommandResult = new SetPriorityCommand(aliceNric, mediumPriority).execute(model);
         Person mediumPriorityAlice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
                 .orElse(null);
 
@@ -87,7 +87,7 @@ public class PriorityCommandTest {
         assertEquals(mediumPriority, mediumPriorityAlice.getPriority());
 
         // change priority from "MEDIUM" to "HIGH"
-        CommandResult thirdCommandResult = new PriorityCommand(aliceNric, highPriority).execute(model);
+        CommandResult thirdCommandResult = new SetPriorityCommand(aliceNric, highPriority).execute(model);
         Person highPriorityAlice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
                 .orElse(null);
 
@@ -95,7 +95,7 @@ public class PriorityCommandTest {
         assertEquals(highPriority, highPriorityAlice.getPriority());
 
         // change priority from "HIGH" to "HIGH"
-        CommandResult fourthCommandResult = new PriorityCommand(aliceNric, highPriority).execute(model);
+        CommandResult fourthCommandResult = new SetPriorityCommand(aliceNric, highPriority).execute(model);
         Person secondHighPriorityAlice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
                 .orElse(null);
 
@@ -103,7 +103,7 @@ public class PriorityCommandTest {
         assertEquals(highPriority, highPriorityAlice.getPriority());
 
         // change priority from "HIGH" to "NONE"
-        CommandResult fifthCommandResult = new PriorityCommand(aliceNric, noPriority).execute(model);
+        CommandResult fifthCommandResult = new SetPriorityCommand(aliceNric, noPriority).execute(model);
         Person noPriorityAlice = model.fetchPersonIfPresent(new NricMatchesPredicate(ALICE.getNric()))
                 .orElse(null);
 

--- a/src/test/java/seedu/address/logic/parser/SetSetPriorityCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SetSetPriorityCommandParserTest.java
@@ -13,7 +13,7 @@ import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_NRIC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_PRIORITY_BOB;
-import static seedu.address.logic.commands.PriorityCommand.MESSAGE_USAGE;
+import static seedu.address.logic.commands.SetPriorityCommand.MESSAGE_USAGE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NRIC;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
@@ -22,32 +22,32 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.Messages;
-import seedu.address.logic.commands.PriorityCommand;
+import seedu.address.logic.commands.SetPriorityCommand;
 import seedu.address.model.person.Nric;
 import seedu.address.model.person.Priority;
 
-public class PriorityCommandParserTest {
-    private final PriorityCommandParser parser = new PriorityCommandParser();
+public class SetSetPriorityCommandParserTest {
+    private final SetPriorityCommandParser parser = new SetPriorityCommandParser();
 
     @Test
     public void parse_allFieldsValid_success() {
         // For Amy
-        PriorityCommand expectedCommandForAmy = new PriorityCommand(new Nric(VALID_NRIC_AMY),
+        SetPriorityCommand expectedCommandForAmy = new SetPriorityCommand(new Nric(VALID_NRIC_AMY),
                 new Priority(VALID_PRIORITY_AMY));
         assertParseSuccess(parser, NRIC_DESC_AMY + PRIORITY_DESC_AMY, expectedCommandForAmy);
 
         // For Bob
-        PriorityCommand expectedCommandForBob = new PriorityCommand(new Nric(VALID_NRIC_BOB),
+        SetPriorityCommand expectedCommandForBob = new SetPriorityCommand(new Nric(VALID_NRIC_BOB),
                 new Priority(VALID_PRIORITY_BOB));
         assertParseSuccess(parser, NRIC_DESC_BOB + PRIORITY_DESC_BOB, expectedCommandForBob);
 
         // Reverse Position of Nric and Priority for Amy
-        PriorityCommand expectedCommandForAmyReverseParameters = new PriorityCommand(new Nric(VALID_NRIC_AMY),
+        SetPriorityCommand expectedCommandForAmyReverseParameters = new SetPriorityCommand(new Nric(VALID_NRIC_AMY),
                 new Priority(VALID_PRIORITY_AMY));
         assertParseSuccess(parser, PRIORITY_DESC_AMY + NRIC_DESC_AMY, expectedCommandForAmyReverseParameters);
 
         // Reverse position of Nric and Priority for Bob
-        PriorityCommand expectedCommandForBobReverseParameters = new PriorityCommand(new Nric(VALID_NRIC_BOB),
+        SetPriorityCommand expectedCommandForBobReverseParameters = new SetPriorityCommand(new Nric(VALID_NRIC_BOB),
                 new Priority(VALID_PRIORITY_BOB));
         assertParseSuccess(parser, PRIORITY_DESC_BOB + NRIC_DESC_BOB, expectedCommandForBobReverseParameters);
     }


### PR DESCRIPTION
Fixes #242  

1. `PriorityCommand` has been changed to `SetPriorityCommand`.
2. All occurrences of `PriorityCommand` has been changed to `SetPriorityCommand` .

3. Removed unused variable in PriorityCommandParser.

4. `PriorityCommandParser` has been changed to `SetPriorityCommandParser`
5. All occurrences of `PriorityCommandParser` has been changed to`SetPriorityCommandParser`