### PR TITLE
Bug: Able to add duplicate medical conditions

### DIFF
--- a/src/main/java/seedu/address/model/person/MedCon.java
+++ b/src/main/java/seedu/address/model/person/MedCon.java
@@ -23,7 +23,7 @@ public class MedCon implements Comparable<MedCon> {
         requireNonNull(medConName);
         checkArgument(!medConName.isEmpty(), MESSAGE_EMPTY_FIELD);
         checkArgument(isValidMedConName(medConName), MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH);
-        this.medConName = medConName;
+        this.medConName = medConName.toUpperCase();
     }
 
     /**

--- a/src/test/java/seedu/address/storage/JsonAdaptedMedConTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedMedConTest.java
@@ -54,8 +54,9 @@ public class JsonAdaptedMedConTest {
     public void constructor_medConObject_createsValidJsonAdaptedMedCon() {
         MedCon medCon = new MedCon(VALID_MEDCON);
         JsonAdaptedMedCon jsonAdaptedMedCon = new JsonAdaptedMedCon(medCon);
-        assertEquals(VALID_MEDCON, jsonAdaptedMedCon.getmedConName());
+        assertEquals(VALID_MEDCON.toUpperCase(), jsonAdaptedMedCon.getmedConName());
     }
+
 
     @Test
     public void getmedConName_validMedCon_returnsCorrectValue() {


### PR DESCRIPTION
Fixes #214

This PR resolves an issue where users could add multiple medical conditions with identical names but different casing.

### Changes:
- MedCon names are now saved in uppercase for consistency.
- Ensures medical conditions are uniformly capitalised for better readability by doctors.
- Comparison between medical conditions is now case-insensitive, preventing duplicate entries with different casing (e.g., "flu" and "Flu").