### PR TITLE
Bug: Non-standardised error messages for medical condition and allergy commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -26,7 +26,7 @@ public class AddAllergyCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds allergy to the patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + "[" + PREFIX_ALLERGY + "ALLERGY]...\n"
+            + PREFIX_ALLERGY + "ALLERGY...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A "
             + PREFIX_ALLERGY + "Pollen "

--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -23,9 +23,10 @@ public class AddAllergyCommand extends Command {
 
     public static final String COMMAND_WORD = "addAllergy";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds allergy to the patient in the address book. "
-            + "Parameters: NRIC (must be a valid NRIC in the system) "
-            + "[" + PREFIX_ALLERGY + "Allergy]...\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds allergy to the patient in MediBase3. \n"
+            + "Parameters: "
+            + PREFIX_NRIC + "NRIC "
+            + "[" + PREFIX_ALLERGY + "ALLERGY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A "
             + PREFIX_ALLERGY + "Pollen "

--- a/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
@@ -23,10 +23,10 @@ public class AddMedConCommand extends Command {
     public static final String COMMAND_WORD = "addMedCon";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Assigns "
-            + "one or more medical conditions to a patient in the address book.\n"
+            + "one or more medical conditions to a patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + PREFIX_MEDCON + "CONDITION...\n"
+            + "[" + PREFIX_MEDCON + "CONDITION]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "T0123456F "
             + PREFIX_MEDCON + "Diabetes "

--- a/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
@@ -26,7 +26,7 @@ public class AddMedConCommand extends Command {
             + "one or more medical conditions to a patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + "[" + PREFIX_MEDCON + "CONDITION]...\n"
+            + PREFIX_MEDCON + "CONDITION...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "T0123456F "
             + PREFIX_MEDCON + "Diabetes "

--- a/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
@@ -23,9 +23,10 @@ public class DelAllergyCommand extends Command {
 
     public static final String COMMAND_WORD = "delAllergy";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes allergy from patient in the address book. "
-            + "Parameters: NRIC (must be a valid NRIC in the system) "
-            + "[" + PREFIX_ALLERGY + "Allergy]...\n"
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes allergy from patient in MediBase3. \n"
+            + "Parameters: "
+            + PREFIX_NRIC + "NRIC "
+            + "[" + PREFIX_ALLERGY + "ALLERGY]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A "
             + PREFIX_ALLERGY + "Pollen "

--- a/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
@@ -26,7 +26,7 @@ public class DelAllergyCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Removes allergy from patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + "[" + PREFIX_ALLERGY + "ALLERGY]...\n"
+            + PREFIX_ALLERGY + "ALLERGY...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "S1234567A "
             + PREFIX_ALLERGY + "Pollen "

--- a/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
@@ -26,7 +26,7 @@ public class DelMedConCommand extends Command {
             + "one or more medical conditions to a patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + "[" + PREFIX_MEDCON + "CONDITION]...\n"
+            + PREFIX_MEDCON + "CONDITION...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "T0123456F "
             + PREFIX_MEDCON + "Diabetes "

--- a/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
@@ -23,10 +23,10 @@ public class DelMedConCommand extends Command {
     public static final String COMMAND_WORD = "delMedCon";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Unassigns "
-            + "one or more medical conditions to a patient in the address book.\n"
+            + "one or more medical conditions to a patient in MediBase3. \n"
             + "Parameters: "
             + PREFIX_NRIC + "NRIC "
-            + PREFIX_MEDCON + "CONDITION...\n"
+            + "[" + PREFIX_MEDCON + "CONDITION]...\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NRIC + "T0123456F "
             + PREFIX_MEDCON + "Diabetes "


### PR DESCRIPTION
Fixes #233 

The invalid command format error messages in `addMedCon`, `delMedCon`, `addAllergy`, and `delAllergy` were inconsistent with the style used by other commands. To maintain a uniform user experience, I updated these messages to match the consistent format used throughout the main functions.

Below are the screenshots of the updated error messages for your review:

1. **AddMedCon Command Error:**
<img width="596" alt="Screenshot 2024-10-29 at 15 05 41" src="https://github.com/user-attachments/assets/a20cb787-2bc6-4aa0-93f7-76c42703005d">

2. **DelMedCon Command Error:**
<img width="608" alt="Screenshot 2024-10-29 at 15 08 01" src="https://github.com/user-attachments/assets/046babb6-5265-42ef-9ef9-4ceb5dd08170">

3. **AddAllergy Command Error:**
<img width="412" alt="Screenshot 2024-10-29 at 15 07 37" src="https://github.com/user-attachments/assets/e77e6fb8-bcd7-4bd2-a1fc-cf2528fb4e28">

4. **DelAllergy Command Error:**
<img width="424" alt="Screenshot 2024-10-29 at 15 06 43" src="https://github.com/user-attachments/assets/8d522411-193e-40b5-9389-e229d6c32a86">



