### PR TITLE
Bug: Unspecific error messages for MedCon and Allergy commands when input is not alphanumeric

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,7 +21,7 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_CONSTRAINTS_LENGTH =
             "length should not exceed the limit of 30 characters";
-    public static final String MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH = " names should be alphanumeric and not "
+    public static final String MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH = "names should be alphanumeric and not "
             + "exceed 30 characters";
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -21,7 +21,7 @@ public class Messages {
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_CONSTRAINTS_LENGTH =
             "length should not exceed the limit of 30 characters";
-    public static final String MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH = "names should be alphanumeric and not "
+    public static final String MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH = "name(s) should be alphanumeric and not "
             + "exceed 30 characters";
 
     /**

--- a/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddAllergyCommand.java
@@ -31,7 +31,7 @@ public class AddAllergyCommand extends Command {
             + PREFIX_ALLERGY + "Pollen "
             + PREFIX_ALLERGY + "Peanut";
 
-    public static final String MESSAGE_ADD_ALLERGY_SUCCESS = "Added allergy: %1$s to Nric: %2$s";
+    public static final String MESSAGE_ADD_ALLERGY_SUCCESS = "Added allergy/allergies: %1$s to Nric: %2$s";
     public static final String PATIENT_DOES_NOT_EXIST = "Patient does not exist in contact list";
     public static final String MESSAGE_DUPLICATE_ALLERGY = "Allergy already assigned: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMedConCommand.java
@@ -32,7 +32,7 @@ public class AddMedConCommand extends Command {
             + PREFIX_MEDCON + "Diabetes "
             + PREFIX_MEDCON + "Hypertension";
 
-    public static final String MESSAGE_ADD_MEDCON_SUCCESS = "Added medical condition: %1$s to Nric: %2$s";
+    public static final String MESSAGE_ADD_MEDCON_SUCCESS = "Added medical condition(s): %1$s to Nric: %2$s";
     public static final String PATIENT_DOES_NOT_EXIST = "Patient does not exist in contact list";
     public static final String MESSAGE_DUPLICATE_MEDCON = "Condition already assigned: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelAllergyCommand.java
@@ -31,7 +31,7 @@ public class DelAllergyCommand extends Command {
             + PREFIX_ALLERGY + "Pollen "
             + PREFIX_ALLERGY + "Peanut";
 
-    public static final String MESSAGE_DELETE_ALLERGY_SUCCESS = "Removed allergy: %1$s from Nric: %2$s";
+    public static final String MESSAGE_DELETE_ALLERGY_SUCCESS = "Removed allergy/allergies: %1$s from Nric: %2$s";
     public static final String PATIENT_DOES_NOT_EXIST = "Patient does not exist in contact list";
     public static final String MESSAGE_ALLERGY_NOT_FOUND = "Allergy not found: %1$s";
 

--- a/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DelMedConCommand.java
@@ -32,7 +32,7 @@ public class DelMedConCommand extends Command {
             + PREFIX_MEDCON + "Diabetes "
             + PREFIX_MEDCON + "Hypertension";
 
-    public static final String MESSAGE_DELETE_MEDCON_SUCCESS = "Removed medical condition: %1$s from Nric: %2$s";
+    public static final String MESSAGE_DELETE_MEDCON_SUCCESS = "Removed medical condition(s): %1$s from Nric: %2$s";
     public static final String PATIENT_DOES_NOT_EXIST = "Patient does not exist in contact list";
     public static final String MESSAGE_MEDCON_NOT_FOUND = "Condition not found: %1$s";
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -1,8 +1,8 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
 import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 
 import java.util.Collection;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_LENGTH;
+import static seedu.address.logic.Messages.MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH;
 import static seedu.address.logic.Messages.MESSAGE_EMPTY_FIELD;
 
 import java.util.Collection;
@@ -210,7 +211,7 @@ public class ParserUtil {
         } else if (allergyStr.length() > 30) {
             throw new ParseException("Allergy " + MESSAGE_CONSTRAINTS_LENGTH);
         } else if (!allergyStr.matches(Allergy.VALIDATION_REGEX)) {
-            throw new ParseException("Invalid allergy format.");
+            throw new ParseException("Allergy " + MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH);
         }
         return new Allergy(allergyStr);
     }
@@ -263,7 +264,7 @@ public class ParserUtil {
         } else if (medConStr.length() > 30) {
             throw new ParseException("Medical condition " + MESSAGE_CONSTRAINTS_LENGTH);
         } else if (!medConStr.matches(MedCon.VALIDATION_REGEX)) {
-            throw new ParseException("Invalid medical condition format.");
+            throw new ParseException("Medical condition " + MESSAGE_CONSTRAINTS_ALPHANUMERIC_LENGTH);
         }
         return new MedCon(medConStr);
     }


### PR DESCRIPTION
Fixes #237 

This PR addresses an issue where the error messages were not specific when a non-alphanumeric medical condition or allergy name was provided. I've updated the `parseAllergy` and `parseMedCon` methods to return more informative error messages, clearly indicating that MedCon and Allergy names must be alphanumeric.

#### Changes Made:
- **parseMedCon** and **parseAllergy** methods have been updated to provide a detailed message for non-alphanumeric inputs.
  
Attached below are screenshots showing the new error messages for your visual review:

<img width="604" alt="Screenshot 2024-10-29 at 15 58 02" src="https://github.com/user-attachments/assets/58cee1ca-f4de-4953-a4c2-83bc8b025c5a">
<img width="518" alt="Screenshot 2024-10-29 at 15 58 29" src="https://github.com/user-attachments/assets/be568819-24dc-4e72-9ffe-f8be15268769">

