### PR TITLE
Bug Fix: Misleading Error Message for Invalid NRIC Input #276

### DIFF
--- a/src/main/java/seedu/address/model/person/Nric.java
+++ b/src/main/java/seedu/address/model/person/Nric.java
@@ -9,7 +9,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Nric {
     public static final String MESSAGE_CONSTRAINTS = "NRIC should start with S, T, F or G, "
-            + "followed by 7 digits, and end with a letter. It should not be blank.";
+            + "followed by 7 digits, and end with a letter.";
     //Regex accounts for both uppercase and lowercase NRIC and FIN formats
     public static final String VALIDATION_REGEX = "(?i)^[STFG]\\d{7}[A-Z]$";
 


### PR DESCRIPTION
Fixes #276

- What changed
     -  Removed the last sentence "it should not be blank"