### PR TITLE
Fix UI visual bug

### DIFF
--- a/src/main/resources/view/AppointmentListCard.fxml
+++ b/src/main/resources/view/AppointmentListCard.fxml
@@ -13,7 +13,7 @@
             <padding>
                 <Insets bottom="5" left="15" right="5" top="5" />
             </padding>
-            <HBox alignment="CENTER">
+            <HBox alignment="BASELINE_LEFT">
                 <Label fx:id="date" styleClass="appointment-date" text="\$date" />
                 <Label fx:id="timePeriod" styleClass="appointment-time" text="\$timePeriod" />
             </HBox>

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -313,6 +313,10 @@
     -fx-padding: 8 1 8 1;
 }
 
+.virtual-flow .corner {
+    -fx-background-color: derive(#1d1d1d, 20%);
+}
+
 #cardPane {
     -fx-background-color: transparent;
     -fx-border-width: 0;


### PR DESCRIPTION
fixes #326 

Long names will no longer shift the position of appointment date&time in the appointment list

White box at the corner of the panels will no longer appear when the horizontal scrollbar appears

![image](https://github.com/user-attachments/assets/f844f94c-7f60-4e99-adeb-42b6d07b6724)
