### PR TITLE
Fix Typo in add/delete medCon error message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -12,7 +12,7 @@ import seedu.address.model.person.Person;
  */
 public class Messages {
 
-    public static final String MESSAGE_EMPTY_FIELD = "field should not by empty";
+    public static final String MESSAGE_EMPTY_FIELD = "field should not be empty";
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_PERSON_NRIC_NOT_FOUND = "The patient with the specified NRIC does not exist";


### PR DESCRIPTION
error message said 'by' instead of 'be' when medCon field was empty in input 

Fixes #325 